### PR TITLE
correct database url in sample env to actual default value

### DIFF
--- a/controller/.env.sample
+++ b/controller/.env.sample
@@ -1,6 +1,8 @@
 # Path to the repository
 THYMIS_REPO_PATH=/var/lib/thymis/repository
-THYMIS_DATABASE_URL=sqlite:///var/lib/thymis/thymis.sqlite
+
+# Path to the database, see https://docs.sqlalchemy.org/en/20/core/engines.html#sqlite
+THYMIS_DATABASE_URL=sqlite:////var/lib/thymis/thymis.sqlite
 
 # Base URL for the application
 THYMIS_BASE_URL=http://localhost:8000


### PR DESCRIPTION
The path format of a sqlalchemy sqlite file is not that intuitive. See https://docs.sqlalchemy.org/en/20/core/engines.html#sqlite

First, I changed the wrong value to the actual default value in the .env.sample. Second, I linked the documentation of sqlalchemy.