### PR TITLE
refactor: remove pull_request_target from CI workflows and simplify conditions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: "Build"
 on:
   pull_request:
-  pull_request_target:
   merge_group:
   push:
     branches:
@@ -9,18 +8,9 @@ on:
 
 jobs:
   build-agent:
-    if: ${{ (( ! (github.event_name == 'pull_request_target') ) || (github.event.pull_request.author_association == 'MEMBER' || contains(github.event.pull_request.labels.*.name, 'trust')) ) && (( ! (github.event_name == 'pull_request') ) || ( ! (github.event.pull_request.author_association == 'MEMBER' || contains(github.event.pull_request.labels.*.name, 'trust')) )) }}
     runs-on: ubuntu-latest
     steps:
-      # - if: ${{ github.event_name != 'pull_request_target' }}
-      #   uses: actions/checkout@v4
-      # - if: ${{ github.event_name == 'pull_request_target' }}
-      #   uses: actions/checkout@v4
-      #   with:
-      #     ref: ${{ github.event.pull_request.merge_commit_sha }}
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha) || '' }}
       - uses: ./.github/actions/setup-nix
         with:
           attic_token: ${{ secrets.ATTIC_TOKEN }}
@@ -32,12 +22,9 @@ jobs:
             nix build .#thymis-agent --print-build-logs
 
   build-thymis-controller:
-    if: ${{ (( ! (github.event_name == 'pull_request_target') ) || (github.event.pull_request.author_association == 'MEMBER' || contains(github.event.pull_request.labels.*.name, 'trust')) ) && (( ! (github.event_name == 'pull_request') ) || ( ! (github.event.pull_request.author_association == 'MEMBER' || contains(github.event.pull_request.labels.*.name, 'trust')) )) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha) || '' }}
       - uses: ./.github/actions/setup-nix
         with:
           attic_token: ${{ secrets.ATTIC_TOKEN }}
@@ -49,12 +36,9 @@ jobs:
             nix build .#thymis-controller --print-build-logs
 
   build-thymis-controller-pi-3-sd-image:
-    if: ${{ (( ! (github.event_name == 'pull_request_target') ) || (github.event.pull_request.author_association == 'MEMBER' || contains(github.event.pull_request.labels.*.name, 'trust')) ) && (( ! (github.event_name == 'pull_request') ) || ( ! (github.event.pull_request.author_association == 'MEMBER' || contains(github.event.pull_request.labels.*.name, 'trust')) )) }}
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha) || '' }}
       - uses: ./.github/actions/setup-nix
         with:
           attic_token: ${{ secrets.ATTIC_TOKEN }}
@@ -66,12 +50,9 @@ jobs:
       - uses: ./.github/actions/assemble-image-and-assert-existence
 
   build-thymis-controller-pi-4-sd-image:
-    if: ${{ (( ! (github.event_name == 'pull_request_target') ) || (github.event.pull_request.author_association == 'MEMBER' || contains(github.event.pull_request.labels.*.name, 'trust')) ) && (( ! (github.event_name == 'pull_request') ) || ( ! (github.event.pull_request.author_association == 'MEMBER' || contains(github.event.pull_request.labels.*.name, 'trust')) )) }}
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha) || '' }}
       - uses: ./.github/actions/setup-nix
         with:
           attic_token: ${{ secrets.ATTIC_TOKEN }}
@@ -84,12 +65,9 @@ jobs:
       - uses: ./.github/actions/assemble-image-and-assert-existence
 
   build-thymis-controller-pi-5-sd-image:
-    if: ${{ (( ! (github.event_name == 'pull_request_target') ) || (github.event.pull_request.author_association == 'MEMBER' || contains(github.event.pull_request.labels.*.name, 'trust')) ) && (( ! (github.event_name == 'pull_request') ) || ( ! (github.event.pull_request.author_association == 'MEMBER' || contains(github.event.pull_request.labels.*.name, 'trust')) )) }}
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha) || '' }}
       - uses: ./.github/actions/setup-nix
         with:
           attic_token: ${{ secrets.ATTIC_TOKEN }}
@@ -102,12 +80,9 @@ jobs:
       - uses: ./.github/actions/assemble-image-and-assert-existence
 
   build-generic-x86_64-image:
-    if: ${{ (( ! (github.event_name == 'pull_request_target') ) || (github.event.pull_request.author_association == 'MEMBER' || contains(github.event.pull_request.labels.*.name, 'trust')) ) && (( ! (github.event_name == 'pull_request') ) || ( ! (github.event.pull_request.author_association == 'MEMBER' || contains(github.event.pull_request.labels.*.name, 'trust')) )) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha) || '' }}
       - uses: ./.github/actions/setup-nix
         with:
           attic_token: ${{ secrets.ATTIC_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
 name: "Test"
 on:
   pull_request:
-  pull_request_target:
   merge_group:
   push:
     branches:
@@ -9,7 +8,6 @@ on:
 
 jobs:
   test-controller:
-    if: ${{ (( ! (github.event_name == 'pull_request_target') ) || (github.event.pull_request.author_association == 'MEMBER' || contains(github.event.pull_request.labels.*.name, 'trust')) ) && (( ! (github.event_name == 'pull_request') ) || ( ! (github.event.pull_request.author_association == 'MEMBER' || contains(github.event.pull_request.labels.*.name, 'trust')) )) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +42,6 @@ jobs:
         working-directory: controller
 
   test-frontend-integration:
-    if: ${{ (( ! (github.event_name == 'pull_request_target') ) || (github.event.pull_request.author_association == 'MEMBER' || contains(github.event.pull_request.labels.*.name, 'trust')) ) && (( ! (github.event_name == 'pull_request') ) || ( ! (github.event.pull_request.author_association == 'MEMBER' || contains(github.event.pull_request.labels.*.name, 'trust')) )) }}
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Important to know: Apparently you can access repo secrets in pull_requests, especially if the workflow is in master.