### PR TITLE
fix: add rebaseWhen option to renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
     "enabled": true
   },
   "automerge": true,
-  "rebaseWhen": "conflicted",
+  "rebaseWhen": "auto",
   "gitIgnoredAuthors": [
     "185514190+thymis-app[bot]@users.noreply.github.com"
   ]


### PR DESCRIPTION
reasoning: from the docs "rebaseWhen=conflicted is not recommended" does not apply to us because we are using a merge queue, due to linearisation

maybe not, idk yet