### PR TITLE
prevent brcmf_set_channel error

### DIFF
--- a/devices.nix
+++ b/devices.nix
@@ -45,7 +45,7 @@ let
         ];
         raspberry-pi-nix.libcamera-overlay.enable = false;
         raspberry-pi-nix.board = "bcm2711";
-        boot.kernelParams = [ "snd_bcm2835.enable_headphones=1" "snd_bcm2835.enable_hdmi=1" ];
+        boot.kernelParams = [ "snd_bcm2835.enable_headphones=1" "snd_bcm2835.enable_hdmi=1" "brcmfmac.roamoff=1" "brcmfmac.feature_disable=0x282000" ];
         hardware.raspberry-pi.config = {
           all = {
             dt-overlays = {


### PR DESCRIPTION
Fix for brcmfmac: brcmf_set_channel: set chanspec fail, reason -52

See: https://github.com/raspberrypi/linux/issues/6049#issuecomment-2642566713