### PR TITLE
fix: end nix module contents with comment is now allowed

### DIFF
--- a/controller/thymis_controller/modules/modules.py
+++ b/controller/thymis_controller/modules/modules.py
@@ -66,7 +66,7 @@ class Module(ABC):
 
             self.write_nix_settings(f, path, module_settings, priority, project)
 
-            f.write("}\n")
+            f.write("\n}\n")
 
         format_nix_file(str(path / filename))
 


### PR DESCRIPTION
add newline before closing brace in Nix file output