### PR TITLE
feat(agent): implement SystemdNotifier for service readiness and status updates

### DIFF
--- a/agent/poetry.lock
+++ b/agent/poetry.lock
@@ -281,7 +281,7 @@ websockets = "^14.1"
 type = "git"
 url = "https://git@github.com/Thymis-io/http-network-relay.git"
 reference = "HEAD"
-resolved_reference = "7de2c345ef264ae1754892202e74077784ed8e6c"
+resolved_reference = "2d6924d4cf222df44eba60c86628994b021f95f6"
 
 [[package]]
 name = "httpcore"

--- a/controller/poetry.lock
+++ b/controller/poetry.lock
@@ -682,7 +682,7 @@ websockets = "^14.1"
 type = "git"
 url = "https://git@github.com/Thymis-io/http-network-relay.git"
 reference = "HEAD"
-resolved_reference = "7de2c345ef264ae1754892202e74077784ed8e6c"
+resolved_reference = "2d6924d4cf222df44eba60c86628994b021f95f6"
 
 [[package]]
 name = "httpcore"

--- a/nix/thymis-device-nixos-module.nix
+++ b/nix/thymis-device-nixos-module.nix
@@ -128,6 +128,7 @@ in
         CONTROLLER_HOST = cfg.agent.controller-url;
       };
       serviceConfig.Restart = "always";
+      serviceConfig.Type = "notify";
     };
 
     documentation = {


### PR DESCRIPTION
Later, we can make services wait for secrets to arrive using the thymis-agent, (using `after=` in conjunction with `ConditionPathExists` probably)