### PR TITLE
disable translation dialog in chromium

### DIFF
--- a/controller/thymis_controller/modules/kiosk.py
+++ b/controller/thymis_controller/modules/kiosk.py
@@ -184,7 +184,7 @@ class Kiosk(modules.Module):
             exec "/run/current-system/sw/bin/xset s off"
             exec "/run/current-system/sw/bin/xset -dpms"
             exec "${{pkgs.unclutter}}/bin/unclutter"
-            exec ${{pkgs.bash}}/bin/bash -c "rm -rf ~/.config/chromium/Singleton*; ${{pkgs.chromium}}/bin/chromium --kiosk '{kiosk_url}' ${{if (pkgs.stdenv.system == "aarch64-linux") then "--disable-gpu" else ""}}"
+            exec ${{pkgs.bash}}/bin/bash -c "rm -rf ~/.config/chromium/Singleton*; ${{pkgs.chromium}}/bin/chromium --kiosk '{kiosk_url}' ${{if (pkgs.stdenv.system == "aarch64-linux") then "--disable-gpu" else ""}} --disable-features=Translate"
             {'exec ${pkgs.bash}/bin/bash -c "mkdir -p $HOME/tigervnc; ${pkgs.tigervnc}/bin/vncpasswd -f <<< \\"'+ vnc_password + '\\" > $HOME/tigervnc/passwd"' if enable_vnc else ''}
             {'exec ${pkgs.tigervnc}/bin/x0vncserver -display :0 -PasswordFile=$HOME/tigervnc/passwd' if enable_vnc else ''}
             exec "${{pkgs.pamixer}}/bin/pamixer --set-volume {volume}"


### PR DESCRIPTION
Removes this translation dialog:
<img width="1058" alt="grafik" src="https://github.com/user-attachments/assets/65b26486-3ead-43c3-b0ef-e3eeb67820ae" />
