### PR TITLE
fix: set LimitNOFILE=infinity for thymis-agent systemd service

### DIFF
--- a/nix/thymis-device-nixos-module.nix
+++ b/nix/thymis-device-nixos-module.nix
@@ -138,6 +138,7 @@ in
       };
       serviceConfig.Restart = "always";
       serviceConfig.Type = "notify";
+      serviceConfig.LimitNOFILE = "infinity";
     };
     systemd.services.thymis-agent-place-secrets = lib.mkIf cfg.agent.enable {
       description = "Thymis agent - place secrets";


### PR DESCRIPTION
## Problem

The thymis-agent process leaks one file descriptor per relay-proxied connection that ends via remote EOF (sshd closes its side before the relay sends `RtEConnectionCloseMessage`). In `edge_agent.py`, `read_from_tcp_and_send()` silently breaks on empty read without closing the writer or removing from `active_connections`.

The default systemd soft fd limit is 1024. Once exhausted, `asyncio.open_connection()` fails with `[Errno 16] Device or resource busy` (Python 3.13 happy-eyeballs translates `EMFILE` as `EBUSY`). This brought down homepi4's terminal/SSH relay today.

## Fix

Set `LimitNOFILE=infinity` as a stopgap while the underlying leak in `edge_agent.py` is addressed separately.

## Root cause (to fix next)

In `edge_agent.py` → `initiate_connection()` → inner `read_from_tcp_and_send()`: add a `try/finally` that calls `writer.close()` + `active_connections.pop()` when the read loop exits.