### PR TITLE
feat: switch deployed device to a different config

### DIFF
--- a/agent/thymis_agent/agent.py
+++ b/agent/thymis_agent/agent.py
@@ -181,6 +181,7 @@ class EtRSwitchToNewConfigResultMessage(BaseModel):
     task_id: uuid.UUID
     success: Optional[bool] = None  # in v3 dev
     error: Optional[str] = None  # in v3 dev
+    configuration_id: str | None = None  # v3 final
     config_commit: str | None = None  # in v3 final
     is_activated: bool | None = None  # in v3 final
     switch_success: bool | None = None  # in v3 final
@@ -218,6 +219,7 @@ class RtEUpdatePublicKeyMessage(BaseModel):
 class RtESwitchToNewConfigMessage(BaseModel):
     kind: Literal["switch_to_new_config"] = "switch_to_new_config"
     new_path_to_config: str
+    configuration_id: str
     config_commit: str
     task_id: uuid.UUID
 
@@ -313,6 +315,7 @@ class Agent(ea.EdgeAgent):
                         AgentToRelayMessage(
                             inner=EtRSwitchToNewConfigResultMessage(
                                 task_id=message.inner.task_id,
+                                configuration_id=message.inner.configuration_id,
                                 config_commit=message.inner.config_commit,
                                 is_activated=False,
                                 switch_success=False,
@@ -370,7 +373,10 @@ class Agent(ea.EdgeAgent):
                     )
                 try:
                     if is_activated:
-                        self.update_config_commit(message.inner.config_commit)
+                        self.update_config_metadata(
+                            message.inner.configuration_id,
+                            message.inner.config_commit,
+                        )
                 except Exception as e:
                     logger.error("Failed to update config commit: %s", e)
 
@@ -445,6 +451,7 @@ class Agent(ea.EdgeAgent):
                             AgentToRelayMessage(
                                 inner=EtRSwitchToNewConfigResultMessage(
                                     task_id=message.inner.task_id,
+                                    configuration_id=message.inner.configuration_id,
                                     config_commit=message.inner.config_commit,
                                     is_activated=False,
                                     switch_success=False,
@@ -463,6 +470,7 @@ class Agent(ea.EdgeAgent):
                         AgentToRelayMessage(
                             inner=EtRSwitchToNewConfigResultMessage(
                                 task_id=message.inner.task_id,
+                                configuration_id=message.inner.configuration_id,
                                 config_commit=message.inner.config_commit,
                                 is_activated=is_activated,
                                 switch_success=switch_success,
@@ -748,7 +756,8 @@ class Agent(ea.EdgeAgent):
                 logger.error("Failed to collect/send network interfaces: %s", e)
             await asyncio.sleep(20)
 
-    def update_config_commit(self, new_commit: str):
+    def update_config_metadata(self, new_config_id: str, new_commit: str):
+        self.agent_metadata["configuration_id"] = new_config_id
         self.agent_metadata["configuration_commit"] = new_commit
         metadata_path = find_file(AGENT_DATA_PATHS, AGENT_METADATA_FILENAME)
         if metadata_path:

--- a/controller/tests/crud/test_switch_config.py
+++ b/controller/tests/crud/test_switch_config.py
@@ -9,9 +9,9 @@ Invariants under test:
 4. Full switch round-trip:
    - switch-config sets pending_config_id
    - device reconnects reporting old id  → deployed_config_id stays old, pending intact
-   - activation clears pending_config_id; deployed_config_id stays as device last reported
+   - activation promotes deployed_config_id to the target and clears pending_config_id
+   - future reconnects should report the new id because agent metadata is updated
 """
-
 
 from thymis_controller import crud, db_models
 
@@ -108,20 +108,18 @@ def test_full_switch_round_trip(db_session):
     assert di_mid.deployed_config_id == "config-a"
     assert di_mid.pending_config_id == "config-b"
 
-    # Step 3: deploy succeeds, is_activated=True — clear pending;
-    # deployed_config_id stays as device last reported (config-a here, device will
-    # self-report config-b on next reconnect after activation)
+    # Step 3: deploy succeeds, is_activated=True — promote target config and clear pending
     crud.deployment_info.update(
         db_session,
         di.id,
+        deployed_config_id="config-b",
         deployed_config_commit="abc123",
         clear_pending_config_id=True,
     )
     di_activated = crud.deployment_info.get_by_id(db_session, di.id)
     assert di_activated.pending_config_id is None
     assert di_activated.deployed_config_commit == "abc123"
-    # deployed_config_id is NOT updated here — device will report config-b on reconnect
-    assert di_activated.deployed_config_id == "config-a"
+    assert di_activated.deployed_config_id == "config-b"
 
     # Step 4: device reconnects after activation reporting new config
     crud.deployment_info.create_or_update_by_public_key(

--- a/controller/tests/crud/test_switch_config.py
+++ b/controller/tests/crud/test_switch_config.py
@@ -10,8 +10,11 @@ Invariants under test:
    - switch-config sets pending_config_id
    - device reconnects reporting old id  → deployed_config_id stays old, pending intact
    - activation promotes deployed_config_id to the target and clears pending_config_id
-   - future reconnects should report the new id because agent metadata is updated
+   - the immediate reconnect report cannot bounce a confirmed switch back
 """
+
+import uuid
+from datetime import datetime, timezone
 
 from thymis_controller import crud, db_models
 
@@ -27,6 +30,32 @@ def make_deployment_info(
     db_session.commit()
     db_session.refresh(di)
     return di
+
+
+def make_completed_switch_task(
+    db_session, deployment_info_id, source_identifier, target_identifier
+):
+    task = db_models.Task(
+        id=uuid.uuid4(),
+        start_time=datetime.now(timezone.utc),
+        end_time=datetime.now(timezone.utc),
+        state="completed",
+        task_type="deploy_device_task",
+        user_session_id=uuid.uuid4(),
+        task_submission_data={
+            "type": "deploy_device_task",
+            "device": {
+                "identifier": target_identifier,
+                "source_identifier": source_identifier,
+                "deployment_info_id": str(deployment_info_id),
+                "deployment_public_key": "key-a",
+                "secrets": [],
+            },
+        },
+    )
+    db_session.add(task)
+    db_session.commit()
+    return task
 
 
 # ---------------------------------------------------------------------------
@@ -121,7 +150,22 @@ def test_full_switch_round_trip(db_session):
     assert di_activated.deployed_config_commit == "abc123"
     assert di_activated.deployed_config_id == "config-b"
 
-    # Step 4: device reconnects after activation reporting new config
+    make_completed_switch_task(db_session, di.id, "config-a", "config-b")
+
+    # Step 4: the agent reconnect for the just-completed switch can still report
+    # the source config until its local metadata has been updated. The
+    # controller-confirmed switch target remains authoritative for that case.
+    crud.deployment_info.create_or_update_by_public_key(
+        db_session,
+        ssh_public_key="key-a",
+        deployed_config_id="config-a",
+        preserve_confirmed_switch=True,
+    )
+    di_reconnected = crud.deployment_info.get_by_id(db_session, di.id)
+    assert di_reconnected.deployed_config_id == "config-b"
+    assert di_reconnected.pending_config_id is None
+
+    # Step 5: device reconnects after activation reporting new config
     crud.deployment_info.create_or_update_by_public_key(
         db_session, ssh_public_key="key-a", deployed_config_id="config-b"
     )

--- a/controller/tests/crud/test_switch_config.py
+++ b/controller/tests/crud/test_switch_config.py
@@ -1,0 +1,132 @@
+"""
+Integration tests for the switch-config / pending_config_id feature.
+
+Invariants under test:
+1. update() with pending_config_id sets the field.
+2. update() with clear_pending_config_id=True clears it without touching deployed_config_id.
+3. create_or_update_by_public_key() does NOT auto-promote pending_config_id;
+   the device-reported deployed_config_id always wins on reconnect.
+4. Full switch round-trip:
+   - switch-config sets pending_config_id
+   - device reconnects reporting old id  → deployed_config_id stays old, pending intact
+   - activation clears pending_config_id; deployed_config_id stays as device last reported
+"""
+
+
+from thymis_controller import crud, db_models
+
+
+def make_deployment_info(
+    db_session, ssh_public_key="key-a", deployed_config_id="config-a"
+):
+    di = db_models.DeploymentInfo(
+        ssh_public_key=ssh_public_key,
+        deployed_config_id=deployed_config_id,
+    )
+    db_session.add(di)
+    db_session.commit()
+    db_session.refresh(di)
+    return di
+
+
+# ---------------------------------------------------------------------------
+# 1. update() sets pending_config_id
+# ---------------------------------------------------------------------------
+
+
+def test_update_sets_pending_config_id(db_session):
+    di = make_deployment_info(db_session)
+
+    updated = crud.deployment_info.update(
+        db_session, di.id, pending_config_id="config-b"
+    )
+
+    assert updated.pending_config_id == "config-b"
+    # deployed_config_id must be untouched
+    assert updated.deployed_config_id == "config-a"
+
+
+# ---------------------------------------------------------------------------
+# 2. clear_pending_config_id=True nulls the field without touching deployed
+# ---------------------------------------------------------------------------
+
+
+def test_clear_pending_config_id(db_session):
+    di = make_deployment_info(db_session)
+    crud.deployment_info.update(db_session, di.id, pending_config_id="config-b")
+
+    updated = crud.deployment_info.update(
+        db_session, di.id, clear_pending_config_id=True
+    )
+
+    assert updated.pending_config_id is None
+    assert updated.deployed_config_id == "config-a"
+
+
+# ---------------------------------------------------------------------------
+# 3. create_or_update_by_public_key does NOT auto-promote pending_config_id
+# ---------------------------------------------------------------------------
+
+
+def test_reconnect_does_not_promote_pending_config_id(db_session):
+    di = make_deployment_info(db_session, deployed_config_id="config-a")
+    # Simulate a pending switch to config-b
+    crud.deployment_info.update(db_session, di.id, pending_config_id="config-b")
+
+    # Device reconnects still reporting the old config (deploy hasn't landed yet)
+    result = crud.deployment_info.create_or_update_by_public_key(
+        db_session,
+        ssh_public_key="key-a",
+        deployed_config_id="config-a",
+    )
+
+    # deployed_config_id reflects what the device reported — config-a
+    assert result.deployed_config_id == "config-a"
+    # pending_config_id is untouched — still config-b
+    assert result.pending_config_id == "config-b"
+
+
+# ---------------------------------------------------------------------------
+# 4. Full switch round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_full_switch_round_trip(db_session):
+    di = make_deployment_info(db_session, deployed_config_id="config-a")
+
+    # Step 1: switch-config endpoint sets pending_config_id
+    crud.deployment_info.update(db_session, di.id, pending_config_id="config-b")
+    di_after_switch = crud.deployment_info.get_by_id(db_session, di.id)
+    assert di_after_switch.pending_config_id == "config-b"
+    assert di_after_switch.deployed_config_id == "config-a"
+
+    # Step 2: device reconnects mid-deploy still reporting old config — pending preserved
+    crud.deployment_info.create_or_update_by_public_key(
+        db_session, ssh_public_key="key-a", deployed_config_id="config-a"
+    )
+    di_mid = crud.deployment_info.get_by_id(db_session, di.id)
+    assert di_mid.deployed_config_id == "config-a"
+    assert di_mid.pending_config_id == "config-b"
+
+    # Step 3: deploy succeeds, is_activated=True — clear pending;
+    # deployed_config_id stays as device last reported (config-a here, device will
+    # self-report config-b on next reconnect after activation)
+    crud.deployment_info.update(
+        db_session,
+        di.id,
+        deployed_config_commit="abc123",
+        clear_pending_config_id=True,
+    )
+    di_activated = crud.deployment_info.get_by_id(db_session, di.id)
+    assert di_activated.pending_config_id is None
+    assert di_activated.deployed_config_commit == "abc123"
+    # deployed_config_id is NOT updated here — device will report config-b on reconnect
+    assert di_activated.deployed_config_id == "config-a"
+
+    # Step 4: device reconnects after activation reporting new config
+    crud.deployment_info.create_or_update_by_public_key(
+        db_session, ssh_public_key="key-a", deployed_config_id="config-b"
+    )
+    di_final = crud.deployment_info.get_by_id(db_session, di.id)
+    assert di_final.deployed_config_id == "config-b"
+    assert di_final.pending_config_id is None

--- a/controller/tests/routes/test_state_device_type_gate.py
+++ b/controller/tests/routes/test_state_device_type_gate.py
@@ -1,0 +1,183 @@
+"""API tests for protecting deployed connected devices from device-type changes."""
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import StaticPool, create_engine
+from sqlalchemy.orm import sessionmaker
+from thymis_controller import crud
+from thymis_controller.config import global_settings
+from thymis_controller.database.base import Base
+from thymis_controller.dependencies import (
+    get_db_session,
+    get_network_relay,
+    get_project,
+    require_valid_user_session,
+)
+from thymis_controller.models.state import Config, State
+from thymis_controller.notifications import NotificationManager
+from thymis_controller.project import Project
+
+
+class FakeNetworkRelay:
+    """Minimal stub for connected-device lookups."""
+
+    def __init__(self):
+        self.public_key_to_connection_id: dict[str, str] = {}
+
+
+def _make_config(identifier, device_type="generic-x86_64"):
+    return Config(
+        displayName=identifier.replace("-", " ").title(),
+        identifier=identifier,
+        modules=[
+            {
+                "type": "thymis_controller.modules.thymis.ThymisDevice",
+                "settings": {"device_type": device_type},
+            }
+        ],
+        tags=[],
+    )
+
+
+def _write_state(project, configs):
+    project.repo.pause_file_watcher()
+    state = State(configs=configs)
+    project.write_state(state)
+    project.repo.add(".")
+    project.repo.commit("test: set state")
+    project.repo.resume_file_watcher()
+    return state
+
+
+@pytest.fixture()
+def state_gate_client(monkeypatch):
+    from thymis_controller.main import app
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TestingSession = sessionmaker(bind=engine)
+
+    tmpdir = tempfile.TemporaryDirectory(delete=False)
+    project_path = Path(tmpdir.name)
+    monkeypatch.setattr(global_settings, "PROJECT_PATH", project_path)
+    subprocess.run(
+        [
+            "ssh-keygen",
+            "-t",
+            "ed25519",
+            "-f",
+            str(project_path / "id_thymis"),
+            "-N",
+            "",
+            "-C",
+            "thymis-controller-test",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    project = Project(project_path, NotificationManager(), engine)
+    fake_network_relay = FakeNetworkRelay()
+
+    def override_get_db():
+        session = TestingSession()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    def override_get_project():
+        return project
+
+    def override_get_network_relay():
+        return fake_network_relay
+
+    def override_authenticate():
+        return True
+
+    app.dependency_overrides[get_db_session] = override_get_db
+    app.dependency_overrides[get_project] = override_get_project
+    app.dependency_overrides[get_network_relay] = override_get_network_relay
+    app.dependency_overrides[require_valid_user_session] = override_authenticate
+
+    client = TestClient(app, raise_server_exceptions=False)
+    client._project = project
+    client._testing_session = TestingSession
+    client._fake_network_relay = fake_network_relay
+    try:
+        yield client
+    finally:
+        for key in [
+            get_db_session,
+            get_project,
+            get_network_relay,
+            require_valid_user_session,
+        ]:
+            app.dependency_overrides.pop(key, None)
+        tmpdir.cleanup()
+
+
+def _create_deployment_info(client, config_id, ssh_public_key="ssh-key-1"):
+    with client._testing_session() as session:
+        deployment_info = crud.deployment_info.create(
+            session,
+            ssh_public_key=ssh_public_key,
+            deployed_config_id=config_id,
+            reachable_deployed_host="10.0.0.1",
+        )
+        return deployment_info.id
+
+
+class TestStateDeviceTypeGate:
+    def test_changing_device_type_for_connected_config_returns_400(
+        self, state_gate_client
+    ):
+        client = state_gate_client
+        _write_state(client._project, [_make_config("config-a")])
+        dep_id = _create_deployment_info(client, "config-a")
+        client._fake_network_relay.public_key_to_connection_id["ssh-key-1"] = "conn-1"
+
+        new_state = State(
+            configs=[_make_config("config-a", device_type="raspberry-pi-4")]
+        )
+        resp = client.patch("/api/state", json=new_state.model_dump(mode="json"))
+
+        assert resp.status_code == 400
+        assert "Cannot change device type" in resp.json()["detail"]
+
+        persisted = client.get("/api/state")
+        assert persisted.status_code == 200
+        assert (
+            persisted.json()["configs"][0]["modules"][0]["settings"]["device_type"]
+            == "generic-x86_64"
+        )
+
+        with client._testing_session() as session:
+            deployment_info = crud.deployment_info.get_by_id(session, dep_id)
+            assert deployment_info.deployed_config_id == "config-a"
+
+    def test_changing_device_type_for_disconnected_config_is_allowed(
+        self, state_gate_client
+    ):
+        client = state_gate_client
+        _write_state(client._project, [_make_config("config-a")])
+        _create_deployment_info(client, "config-a")
+
+        new_state = State(
+            configs=[_make_config("config-a", device_type="raspberry-pi-4")]
+        )
+        resp = client.patch("/api/state", json=new_state.model_dump(mode="json"))
+
+        assert resp.status_code == 200, resp.text
+        assert (
+            resp.json()["configs"][0]["modules"][0]["settings"]["device_type"]
+            == "raspberry-pi-4"
+        )

--- a/controller/tests/routes/test_switch_config_activation.py
+++ b/controller/tests/routes/test_switch_config_activation.py
@@ -1,0 +1,88 @@
+import asyncio
+import uuid
+from datetime import datetime, timezone
+
+import thymis_agent.agent as agent
+import thymis_controller.crud.task as crud_task
+from thymis_controller import crud, models
+from thymis_controller.network_relay import NetworkRelay
+from thymis_controller.notifications import NotificationManager
+
+
+class FakeExecutor:
+    def __init__(self):
+        self.messages = []
+
+    def send_message_to_task(self, task_id, message):
+        self.messages.append((task_id, message))
+
+
+class FakeTaskController:
+    def __init__(self):
+        self.executor = FakeExecutor()
+
+
+def _create_switch_task(db_session, deployment_info_id):
+    task_data = models.DeployDeviceTaskSubmission(
+        device=models.DeployDeviceInformation(
+            identifier="config-b",
+            source_identifier="config-a",
+            deployment_info_id=deployment_info_id,
+            deployment_public_key="key-a",
+            secrets=[],
+        ),
+        project_path="/project",
+        ssh_key_path="/project/id_thymis",
+        known_hosts_path="/tmp/known_hosts",
+        controller_ssh_pubkey="controller-key",
+        controller_access_client_endpoint="ws://127.0.0.1:8080/agent/relay_for_clients",
+        access_client_token="token",
+        config_commit="commit-b",
+    )
+    return crud_task.create(
+        db_session,
+        start_time=datetime.now(timezone.utc),
+        state="running",
+        task_type=task_data.type,
+        user_session_id=uuid.uuid4(),
+        task_submission_data=task_data.model_dump(mode="json"),
+        parent_task_id=None,
+    )
+
+
+def test_switch_activation_promotes_deployed_config_id_from_task(db_session):
+    deployment_info = crud.deployment_info.create(
+        db_session,
+        ssh_public_key="key-a",
+        deployed_config_id="config-a",
+    )
+    crud.deployment_info.update(
+        db_session, deployment_info.id, pending_config_id="config-b"
+    )
+    task = _create_switch_task(db_session, deployment_info.id)
+
+    relay = NetworkRelay(db_session.bind, NotificationManager())
+    relay.connection_id_to_public_key["conn-1"] = "key-a"
+    relay.task_controller = FakeTaskController()
+
+    asyncio.run(
+        relay.handle_custom_agent_message(
+            agent.AgentToRelayMessage(
+                inner=agent.EtRSwitchToNewConfigResultMessage(
+                    task_id=task.id,
+                    switch_success=True,
+                    is_activated=True,
+                    config_commit="commit-b",
+                    stdout="",
+                    stderr="activating the configuration...",
+                )
+            ),
+            "conn-1",
+        )
+    )
+
+    updated = crud.deployment_info.get_by_id(db_session, deployment_info.id)
+    assert updated.deployed_config_id == "config-b"
+    assert updated.pending_config_id is None
+    assert updated.deployed_config_commit == "commit-b"
+    assert relay.task_controller.executor.messages

--- a/controller/tests/routes/test_switch_config_api.py
+++ b/controller/tests/routes/test_switch_config_api.py
@@ -6,6 +6,7 @@ calling the CRUD update path directly. Test setup seeds deployment_info rows
 directly so the test does not depend on Playwright-only routes.
 """
 
+import asyncio
 import subprocess
 import tempfile
 import uuid
@@ -145,6 +146,8 @@ def switch_test_client(monkeypatch):
         text=True,
     )
     monkeypatch.setattr(global_settings, "PROJECT_PATH", project_path)
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     project = Project(project_path, NotificationManager(), engine)
 
     fake_network_relay = FakeNetworkRelay()
@@ -182,7 +185,11 @@ def switch_test_client(monkeypatch):
     client._fake_task_controller = fake_task_controller
     client._project = project
     client._testing_session = TestingSession
-    yield client
+    try:
+        yield client
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
 
     tmpdir.cleanup()
     for key in [

--- a/controller/tests/routes/test_switch_config_api.py
+++ b/controller/tests/routes/test_switch_config_api.py
@@ -1,0 +1,333 @@
+"""
+API-level integration tests for the switch-config endpoint.
+
+exercise the switch-config behavior through FastAPI's TestClient instead of
+calling the CRUD update path directly. Test setup seeds deployment_info rows
+directly so the test does not depend on Playwright-only routes.
+"""
+
+import subprocess
+import tempfile
+import uuid
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import StaticPool, create_engine
+from sqlalchemy.orm import sessionmaker
+from thymis_controller import crud
+from thymis_controller.config import global_settings
+from thymis_controller.database.base import Base
+from thymis_controller.dependencies import (
+    get_db_session,
+    get_network_relay,
+    get_project,
+    get_task_controller,
+    require_valid_user_session,
+)
+from thymis_controller.models.state import Config, State
+from thymis_controller.notifications import NotificationManager
+from thymis_controller.project import Project
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_state(project, configs):
+    """Write a state.json with the given configs and commit so repo stays clean."""
+    project.repo.pause_file_watcher()
+    state = State(configs=configs)
+    project.write_state(state)
+    project.repo.add(".")
+    project.repo.commit("test: set state")
+    project.repo.resume_file_watcher()
+    return state
+
+
+def _make_config(identifier, displayName=None):
+    return Config(
+        displayName=displayName or identifier.replace("-", " ").title(),
+        identifier=identifier,
+        modules=[],
+        tags=[],
+    )
+
+
+def _create_deployment_info(client, config_id, ssh_public_key="ssh-ed25519 AAAA"):
+    """Seed deployment_info setup data, then read it back through the API."""
+    with client._testing_session() as session:
+        deployment_info = crud.deployment_info.create(
+            session,
+            ssh_public_key=ssh_public_key,
+            deployed_config_id=config_id,
+            reachable_deployed_host="10.0.0.1",
+        )
+        client._project.update_known_hosts(session)
+        dep_id = deployment_info.id
+    return _get_deployment_info(client, dep_id)
+
+
+def _get_deployment_info(client, dep_id):
+    resp = client.get(f"/api/deployment_info/{dep_id}")
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class FakeNetworkRelay:
+    """Minimal stub — lets the endpoint read public_key_to_connection_id."""
+
+    def __init__(self):
+        self.public_key_to_connection_id: dict[str, str | None] = {}
+
+
+class FakeTaskController:
+    """Records task submissions so tests can assert what was submitted."""
+
+    def __init__(self):
+        self.submissions: list[dict] = []
+        self.access_client_endpoint = "http://localhost:8000"
+
+    def submit(self, model, user_session_id=None, db_session=None):
+        task_id = uuid.uuid4()
+        self.submissions.append(
+            {
+                "task_id": task_id,
+                "model": model,
+                "user_session_id": user_session_id,
+            }
+        )
+
+        class _Task:
+            id = task_id
+
+        return _Task()
+
+
+@pytest.fixture()
+def switch_test_client(monkeypatch):
+    """TestClient wired up with stubs for network_relay and task_controller.
+
+    Creates its own engine, project, and db_session so the Project has a real
+    Engine — which is what it expects for opening its own sessions.
+    """
+    from thymis_controller.main import app
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TestingSession = sessionmaker(bind=engine)
+
+    tmpdir = tempfile.TemporaryDirectory(delete=False)
+    project_path = Path(tmpdir.name)
+    subprocess.run(
+        [
+            "ssh-keygen",
+            "-t",
+            "ed25519",
+            "-f",
+            str(project_path / "id_thymis"),
+            "-N",
+            "",
+            "-C",
+            "thymis-controller-test",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    monkeypatch.setattr(global_settings, "PROJECT_PATH", project_path)
+    project = Project(project_path, NotificationManager(), engine)
+
+    fake_network_relay = FakeNetworkRelay()
+    fake_task_controller = FakeTaskController()
+
+    def override_get_db():
+        session = TestingSession()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    def override_get_project():
+        return project
+
+    def override_get_task_controller():
+        return fake_task_controller
+
+    def override_get_network_relay():
+        return fake_network_relay
+
+    def override_authenticate():
+        return True
+
+    app.dependency_overrides[get_db_session] = override_get_db
+    app.dependency_overrides[get_project] = override_get_project
+    app.dependency_overrides[get_task_controller] = override_get_task_controller
+    app.dependency_overrides[get_network_relay] = override_get_network_relay
+    app.dependency_overrides[require_valid_user_session] = override_authenticate
+
+    client = TestClient(
+        app, cookies={"session-id": str(uuid.uuid4())}, raise_server_exceptions=False
+    )
+    client._fake_network_relay = fake_network_relay
+    client._fake_task_controller = fake_task_controller
+    client._project = project
+    client._testing_session = TestingSession
+    yield client
+
+    tmpdir.cleanup()
+    for key in [
+        get_db_session,
+        get_project,
+        get_task_controller,
+        get_network_relay,
+        require_valid_user_session,
+    ]:
+        app.dependency_overrides.pop(key, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSwitchConfigAPI:
+    """Exercise POST /api/action/switch-config through the HTTP layer."""
+
+    def test_switch_config_sets_pending(self, switch_test_client):
+        """Switching sets pending_config_id; device is NOT connected so deploy is skipped."""
+        client = switch_test_client
+        project = client._project
+        _write_state(project, [_make_config("config-a"), _make_config("config-b")])
+
+        dep = _create_deployment_info(client, "config-a")
+        dep_id = dep["id"]
+
+        resp = client.post(
+            "/api/action/switch-config",
+            params={"deployment_info_id": dep_id, "new_config_id": "config-b"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "not connected" in body["message"]
+
+        updated = _get_deployment_info(client, dep_id)
+        assert updated["pending_config_id"] == "config-b"
+        assert updated["deployed_config_id"] == "config-a"
+        assert len(client._fake_task_controller.submissions) == 0
+
+    def test_switch_config_device_connected_submits_task(self, switch_test_client):
+        """When the device is connected, a deploy task is submitted."""
+        client = switch_test_client
+        project = client._project
+        _write_state(project, [_make_config("config-a"), _make_config("config-b")])
+
+        dep = _create_deployment_info(client, "config-a", ssh_public_key="ssh-key-1")
+
+        client._fake_network_relay.public_key_to_connection_id["ssh-key-1"] = "conn-1"
+
+        resp = client.post(
+            "/api/action/switch-config",
+            params={"deployment_info_id": dep["id"], "new_config_id": "config-b"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "deploy started" in body["message"]
+        assert "task_id" in body
+
+        assert len(client._fake_task_controller.submissions) == 1
+        submission = client._fake_task_controller.submissions[0]
+        assert submission["model"].devices[0].identifier == "config-b"
+        assert submission["model"].devices[0].deployment_info_id == uuid.UUID(dep["id"])
+
+    def test_switch_config_missing_config_returns_404(self, switch_test_client):
+        client = switch_test_client
+        _write_state(client._project, [_make_config("config-a")])
+
+        dep = _create_deployment_info(client, "config-a")
+
+        resp = client.post(
+            "/api/action/switch-config",
+            params={"deployment_info_id": dep["id"], "new_config_id": "nonexistent"},
+        )
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["detail"]
+
+    def test_switch_config_missing_deployment_info_returns_404(
+        self, switch_test_client
+    ):
+        client = switch_test_client
+        _write_state(
+            client._project, [_make_config("config-a"), _make_config("config-b")]
+        )
+
+        fake_id = str(uuid.uuid4())
+        resp = client.post(
+            "/api/action/switch-config",
+            params={"deployment_info_id": fake_id, "new_config_id": "config-b"},
+        )
+        assert resp.status_code == 404
+        assert "Deployment info not found" in resp.json()["detail"]
+
+    def test_switch_config_dirty_repo_returns_409(self, switch_test_client):
+        client = switch_test_client
+        project = client._project
+        _write_state(project, [_make_config("config-a"), _make_config("config-b")])
+
+        (project.repo_dir / "dirty-file.txt").write_text("dirty")
+
+        dep = _create_deployment_info(client, "config-a")
+
+        resp = client.post(
+            "/api/action/switch-config",
+            params={"deployment_info_id": dep["id"], "new_config_id": "config-b"},
+        )
+        assert resp.status_code == 409
+        assert "dirty" in resp.json()["detail"].lower()
+
+    def test_get_deployment_info_shows_pending(self, switch_test_client):
+        """GET /api/deployment_info/{id} reflects pending_config_id."""
+        client = switch_test_client
+        project = client._project
+        _write_state(project, [_make_config("config-a"), _make_config("config-b")])
+
+        dep = _create_deployment_info(client, "config-a")
+        assert dep["pending_config_id"] is None
+
+        client.post(
+            "/api/action/switch-config",
+            params={"deployment_info_id": dep["id"], "new_config_id": "config-b"},
+        )
+
+        updated = _get_deployment_info(client, dep["id"])
+        assert updated["pending_config_id"] == "config-b"
+
+    def test_get_all_deployment_infos_shows_pending(self, switch_test_client):
+        """GET /api/all_deployment_infos reflects pending_config_id."""
+        client = switch_test_client
+        _write_state(
+            client._project, [_make_config("config-a"), _make_config("config-b")]
+        )
+
+        dep = _create_deployment_info(client, "config-a")
+
+        client.post(
+            "/api/action/switch-config",
+            params={"deployment_info_id": dep["id"], "new_config_id": "config-b"},
+        )
+
+        resp = client.get("/api/all_deployment_infos")
+        assert resp.status_code == 200
+        infos = resp.json()
+        matching = [i for i in infos if i["id"] == dep["id"]]
+        assert len(matching) == 1
+        assert matching[0]["pending_config_id"] == "config-b"

--- a/controller/tests/routes/test_switch_config_api.py
+++ b/controller/tests/routes/test_switch_config_api.py
@@ -247,6 +247,7 @@ class TestSwitchConfigAPI:
         assert len(client._fake_task_controller.submissions) == 1
         submission = client._fake_task_controller.submissions[0]
         assert submission["model"].devices[0].identifier == "config-b"
+        assert submission["model"].devices[0].source_identifier == "config-a"
         assert submission["model"].devices[0].deployment_info_id == uuid.UUID(dep["id"])
 
     def test_switch_config_missing_config_returns_404(self, switch_test_client):

--- a/controller/tests/routes/test_switch_config_api.py
+++ b/controller/tests/routes/test_switch_config_api.py
@@ -46,11 +46,16 @@ def _write_state(project, configs):
     return state
 
 
-def _make_config(identifier, displayName=None):
+def _make_config(identifier, displayName=None, device_type="generic-x86_64"):
     return Config(
         displayName=displayName or identifier.replace("-", " ").title(),
         identifier=identifier,
-        modules=[],
+        modules=[
+            {
+                "type": "thymis_controller.modules.thymis.ThymisDevice",
+                "settings": {"device_type": device_type},
+            }
+        ],
         tags=[],
     )
 
@@ -258,6 +263,31 @@ class TestSwitchConfigAPI:
         assert submission["model"].device.identifier == "config-b"
         assert submission["model"].device.source_identifier == "config-a"
         assert submission["model"].device.deployment_info_id == uuid.UUID(dep["id"])
+
+    def test_switch_config_different_device_type_returns_400(self, switch_test_client):
+        """Switching is only valid between configs for the same device type."""
+        client = switch_test_client
+        _write_state(
+            client._project,
+            [
+                _make_config("config-a", device_type="raspberry-pi-4"),
+                _make_config("config-b", device_type="generic-x86_64"),
+            ],
+        )
+
+        dep = _create_deployment_info(client, "config-a")
+
+        resp = client.post(
+            "/api/action/switch-config",
+            params={"deployment_info_id": dep["id"], "new_config_id": "config-b"},
+        )
+
+        assert resp.status_code == 400
+        assert "different device types" in resp.json()["detail"]
+
+        updated = _get_deployment_info(client, dep["id"])
+        assert updated["pending_config_id"] is None
+        assert len(client._fake_task_controller.submissions) == 0
 
     def test_switch_config_missing_config_returns_404(self, switch_test_client):
         client = switch_test_client

--- a/controller/tests/routes/test_switch_config_api.py
+++ b/controller/tests/routes/test_switch_config_api.py
@@ -246,9 +246,11 @@ class TestSwitchConfigAPI:
 
         assert len(client._fake_task_controller.submissions) == 1
         submission = client._fake_task_controller.submissions[0]
-        assert submission["model"].devices[0].identifier == "config-b"
-        assert submission["model"].devices[0].source_identifier == "config-a"
-        assert submission["model"].devices[0].deployment_info_id == uuid.UUID(dep["id"])
+        assert submission["model"].type == "deploy_device_task"
+        assert submission["model"].parent_task_id is None
+        assert submission["model"].device.identifier == "config-b"
+        assert submission["model"].device.source_identifier == "config-a"
+        assert submission["model"].device.deployment_info_id == uuid.UUID(dep["id"])
 
     def test_switch_config_missing_config_returns_404(self, switch_test_client):
         client = switch_test_client

--- a/controller/tests/utils/test_worker_access_client.py
+++ b/controller/tests/utils/test_worker_access_client.py
@@ -1,0 +1,18 @@
+import sys
+import uuid
+
+from thymis_controller.task.worker import access_client_proxy_command
+
+
+def test_access_client_proxy_command_uses_worker_python():
+    deployment_info_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+    command = access_client_proxy_command(
+        "ws://127.0.0.1:8080/agent/relay", deployment_info_id
+    )
+
+    assert command == (
+        f"{sys.executable} -m thymis_controller.access_client "
+        f"ws://127.0.0.1:8080/agent/relay {deployment_info_id}"
+    )
+    assert not command.startswith("python -m thymis_controller.access_client")

--- a/controller/thymis_controller/alembic/versions/b1c2d3e4f5a6_add_pending_config_id_to_deployment_info.py
+++ b/controller/thymis_controller/alembic/versions/b1c2d3e4f5a6_add_pending_config_id_to_deployment_info.py
@@ -1,0 +1,26 @@
+"""add pending_config_id to deployment_info
+
+Revision ID: b1c2d3e4f5a6
+Revises: a1b2c3d4e5f6
+Create Date: 2026-04-14 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b1c2d3e4f5a6"
+down_revision = "a1b2c3d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("deployment_info", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("pending_config_id", sa.String(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("deployment_info", schema=None) as batch_op:
+        batch_op.drop_column("pending_config_id")

--- a/controller/thymis_controller/alembic/versions/b1c2d3e4f5a6_add_pending_config_id_to_deployment_info.py
+++ b/controller/thymis_controller/alembic/versions/b1c2d3e4f5a6_add_pending_config_id_to_deployment_info.py
@@ -1,7 +1,7 @@
 """add pending_config_id to deployment_info
 
 Revision ID: b1c2d3e4f5a6
-Revises: a1b2c3d4e5f6
+Revises: b7e2f1a3c8d9
 Create Date: 2026-04-14 00:00:00.000000
 
 """
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "b1c2d3e4f5a6"
-down_revision = "a1b2c3d4e5f6"
+down_revision = "b7e2f1a3c8d9"
 branch_labels = None
 depends_on = None
 

--- a/controller/thymis_controller/crud/deployment_info.py
+++ b/controller/thymis_controller/crud/deployment_info.py
@@ -1,6 +1,6 @@
 import os
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 from sqlalchemy import nullslast
@@ -81,12 +81,41 @@ def update(
     return deployment_info
 
 
+def _latest_completed_switch_for_deployment_info(
+    session: Session, deployment_info_id: uuid.UUID
+) -> tuple[str, str] | None:
+    recent_cutoff = datetime.now(timezone.utc) - timedelta(minutes=10)
+    tasks = (
+        session.query(db_models.Task)
+        .filter(
+            db_models.Task.task_type == "deploy_device_task",
+            db_models.Task.state == "completed",
+            db_models.Task.end_time >= recent_cutoff,
+        )
+        .order_by(db_models.Task.start_time.desc())
+        .limit(50)
+        .all()
+    )
+    for task in tasks:
+        task_data = task.task_submission_data or {}
+        device = task_data.get("device", {})
+        if device.get("deployment_info_id") != str(deployment_info_id):
+            continue
+        source_identifier = device.get("source_identifier")
+        target_identifier = device.get("identifier")
+        if source_identifier and target_identifier:
+            return source_identifier, target_identifier
+    return None
+
+
 def create_or_update_by_public_key(
     session: Session,
     ssh_public_key: str,
     deployed_config_id: str,
     reachable_deployed_host: str | None = None,
     network_interfaces: list | None = None,
+    *,
+    preserve_confirmed_switch: bool = False,
 ) -> db_models.DeploymentInfo:
     deployment_info = (
         session.query(db_models.DeploymentInfo)
@@ -94,15 +123,22 @@ def create_or_update_by_public_key(
         .first()
     )
     if deployment_info:
-        # Accept the device-reported id as ground truth.
-        # pending_config_id is cleared only when the device confirms activation
-        # via EtRSwitchToNewConfigResultMessage (is_activated=True).
+        effective_deployed_config_id = deployed_config_id
+        if preserve_confirmed_switch and deployment_info.pending_config_id is None:
+            latest_switch = _latest_completed_switch_for_deployment_info(
+                session, deployment_info.id
+            )
+            if latest_switch is not None:
+                source_identifier, target_identifier = latest_switch
+                if deployed_config_id == source_identifier:
+                    effective_deployed_config_id = target_identifier
+
         return update(
             session,
             deployment_info.id,
             ssh_public_key,
             deployed_config_commit=None,
-            deployed_config_id=deployed_config_id,
+            deployed_config_id=effective_deployed_config_id,
             reachable_deployed_host=reachable_deployed_host,
             last_seen=datetime.now(timezone.utc),
             network_interfaces=network_interfaces,

--- a/controller/thymis_controller/crud/deployment_info.py
+++ b/controller/thymis_controller/crud/deployment_info.py
@@ -48,6 +48,8 @@ def update(
     network_interfaces: list | None = None,
     location: str | None = _UNSET,
     name: str | None = _UNSET,
+    pending_config_id: str | None = None,
+    clear_pending_config_id: bool = False,
 ) -> db_models.DeploymentInfo | None:
     deployment_info = session.get(db_models.DeploymentInfo, id)
     if deployment_info is None:
@@ -70,6 +72,10 @@ def update(
         deployment_info.location = location
     if name is not _UNSET:
         deployment_info.name = name
+    if pending_config_id is not None:
+        deployment_info.pending_config_id = pending_config_id
+    if clear_pending_config_id:
+        deployment_info.pending_config_id = None
     session.commit()
     session.refresh(deployment_info)
     return deployment_info
@@ -80,6 +86,7 @@ def create_or_update_by_public_key(
     ssh_public_key: str,
     deployed_config_id: str,
     reachable_deployed_host: str | None = None,
+    network_interfaces: list | None = None,
 ) -> db_models.DeploymentInfo:
     deployment_info = (
         session.query(db_models.DeploymentInfo)
@@ -87,6 +94,9 @@ def create_or_update_by_public_key(
         .first()
     )
     if deployment_info:
+        # Accept the device-reported id as ground truth.
+        # pending_config_id is cleared only when the device confirms activation
+        # via EtRSwitchToNewConfigResultMessage (is_activated=True).
         return update(
             session,
             deployment_info.id,
@@ -95,6 +105,7 @@ def create_or_update_by_public_key(
             deployed_config_id=deployed_config_id,
             reachable_deployed_host=reachable_deployed_host,
             last_seen=datetime.now(timezone.utc),
+            network_interfaces=network_interfaces,
         )
     return create(
         session,

--- a/controller/thymis_controller/db_models/deployment_info.py
+++ b/controller/thymis_controller/db_models/deployment_info.py
@@ -21,6 +21,7 @@ class DeploymentInfo(Base):
     ssh_public_key: Mapped[str] = mapped_column(nullable=False)
     deployed_config_commit: Mapped[str | None] = mapped_column(nullable=True)
     deployed_config_id: Mapped[str | None] = mapped_column(nullable=True)
+    pending_config_id: Mapped[str | None] = mapped_column(nullable=True)
 
     reachable_deployed_host: Mapped[str | None]
 

--- a/controller/thymis_controller/models/device.py
+++ b/controller/thymis_controller/models/device.py
@@ -47,6 +47,7 @@ class DeploymentInfo(BaseModel):
     deployed_config_commit: str | None
     deployed_config_id: str | None
     reachable_deployed_host: str | None
+    pending_config_id: str | None
     last_seen: Optional[datetime]
     first_seen: Optional[datetime]
     hardware_devices: List["HardwareDevice"]
@@ -74,6 +75,7 @@ class DeploymentInfo(BaseModel):
             ssh_public_key=deployment_info.ssh_public_key,
             deployed_config_commit=deployment_info.deployed_config_commit,
             deployed_config_id=deployment_info.deployed_config_id,
+            pending_config_id=deployment_info.pending_config_id,
             reachable_deployed_host=deployment_info.reachable_deployed_host,
             hardware_devices=deployment_info.hardware_devices,
             last_seen=deployment_info.last_seen,

--- a/controller/thymis_controller/models/state.py
+++ b/controller/thymis_controller/models/state.py
@@ -17,11 +17,20 @@ class ModuleSettings(BaseModel):
     settings: Dict[str, JsonValue]
 
 
+THYMIS_DEVICE_MODULE_TYPE = "thymis_controller.modules.thymis.ThymisDevice"
+
+
 class Config(BaseModel):
     displayName: str
     identifier: str
     modules: List[ModuleSettings]
     tags: List[str]
+
+    def device_type(self):
+        for module in self.modules:
+            if module.type == THYMIS_DEVICE_MODULE_TYPE:
+                return module.settings.get("device_type")
+        return None
 
 
 class Tag(BaseModel):

--- a/controller/thymis_controller/models/task.py
+++ b/controller/thymis_controller/models/task.py
@@ -202,6 +202,7 @@ class TaskSubmissionDataWrapper(BaseModel):
 
 class DeployDeviceInformation(BaseModel):
     identifier: str
+    source_identifier: str | None = None
     deployment_info_id: uuid.UUID
     deployment_public_key: str
     secrets: list[agent.SecretForDevice] = []

--- a/controller/thymis_controller/models/task.py
+++ b/controller/thymis_controller/models/task.py
@@ -357,6 +357,7 @@ class AgentShouldSwitchToNewConfigurationUpdate(BaseModel):
     type: Literal[
         "agent_should_switch_to_new_configuration"
     ] = "agent_should_switch_to_new_configuration"
+    configuration_id: str
     path_to_configuration: str
     deployment_info_id: uuid.UUID
     config_commit: str

--- a/controller/thymis_controller/network_relay.py
+++ b/controller/thymis_controller/network_relay.py
@@ -122,10 +122,13 @@ class NetworkRelay(nr.NetworkRelay):
                         )
                         raise ValueError("Deployment info not found")
                     if inner.is_activated:
+                        # Clear the pending indicator; the device will self-report the new
+                        # deployed_config_id on reconnect.
                         crud_deployment_info.update(
                             db_session,
                             deployment_info[0].id,
                             deployed_config_commit=inner.config_commit,
+                            clear_pending_config_id=True,
                         )
                 self.task_controller.executor.send_message_to_task(
                     inner.task_id,
@@ -438,50 +441,60 @@ class NetworkRelay(nr.NetworkRelay):
                 secrets = []
                 secret_infos = []
                 state = self.task_controller.project.read_state()
+                start_message = self.connection_id_to_start_message[connection_id]
                 config = next(
-                    config
-                    for config in state.configs
-                    if config.identifier
-                    == self.connection_id_to_start_message[
-                        connection_id
-                    ].deployed_config_id
-                )
-                modules = self.task_controller.project.get_modules_for_config(
-                    state, config
-                )
-                for module, settings in modules:
-                    for secret_type, secret in module.register_secret_settings(
-                        settings, self.task_controller.project
-                    ):
-                        secrets.append(uuid.UUID(secret))
-                        secret_infos.append(
-                            agent.SecretForDevice(
-                                secret_id=secret,
-                                path=secret_type.on_device_path,
-                                owner=secret_type.on_device_owner,
-                                group=secret_type.on_device_group,
-                                mode=secret_type.on_device_mode,
-                            )
-                        )
-                processed_secrets = self.task_controller.project.get_processed_secrets(
-                    db_session,
-                    secrets,
-                    ssh.Recipient.from_str(
-                        self.connection_id_to_public_key[connection_id]
+                    (
+                        config
+                        for config in state.configs
+                        if config.identifier == start_message.deployed_config_id
                     ),
+                    None,
                 )
-
-                await edge_agent_connection.send_text(
-                    agent.RelayToAgentMessage(
-                        inner=agent.RtESendSecretsMessage(
-                            secrets={
-                                k: base64.b64encode(v).decode("utf-8")
-                                for k, v in processed_secrets.items()
-                            },
-                            secret_infos=secret_infos,
+                if config is None:
+                    logger.warning(
+                        "Config '%s' not found for deployment_info %s; skipping secret push",
+                        start_message.deployed_config_id,
+                        deployment_info_id,
+                    )
+                else:
+                    modules = self.task_controller.project.get_modules_for_config(
+                        state, config
+                    )
+                    for module, settings in modules:
+                        for secret_type, secret in module.register_secret_settings(
+                            settings, self.task_controller.project
+                        ):
+                            secrets.append(uuid.UUID(secret))
+                            secret_infos.append(
+                                agent.SecretForDevice(
+                                    secret_id=secret,
+                                    path=secret_type.on_device_path,
+                                    owner=secret_type.on_device_owner,
+                                    group=secret_type.on_device_group,
+                                    mode=secret_type.on_device_mode,
+                                )
+                            )
+                    processed_secrets = (
+                        self.task_controller.project.get_processed_secrets(
+                            db_session,
+                            secrets,
+                            ssh.Recipient.from_str(
+                                self.connection_id_to_public_key[connection_id]
+                            ),
                         )
-                    ).model_dump_json()
-                )
+                    )
+
+                    await edge_agent_connection.send_text(
+                        agent.RelayToAgentMessage(
+                            inner=agent.RtESendSecretsMessage(
+                                secrets={
+                                    k: base64.b64encode(v).decode("utf-8")
+                                    for k, v in processed_secrets.items()
+                                },
+                                secret_infos=secret_infos,
+                            )
+                        ).model_dump_json()
+                    )
 
                 await edge_agent_connection.send_text(
                     agent.RelayToAgentMessage(

--- a/controller/thymis_controller/network_relay.py
+++ b/controller/thymis_controller/network_relay.py
@@ -14,6 +14,7 @@ import thymis_controller.crud.agent_token as crud_agent_token
 import thymis_controller.crud.deployment_info as crud_deployment_info
 import thymis_controller.crud.device_metric as crud_device_metric
 import thymis_controller.crud.hardware_device as crud_hardware_device
+import thymis_controller.crud.task as crud_task
 import thymis_controller.models.task as models_task
 from fastapi import WebSocket
 from fastapi.concurrency import run_in_threadpool
@@ -122,11 +123,25 @@ class NetworkRelay(nr.NetworkRelay):
                         )
                         raise ValueError("Deployment info not found")
                     if inner.is_activated:
-                        # Clear the pending indicator; the device will self-report the new
-                        # deployed_config_id on reconnect.
+                        activated_config_id = inner.configuration_id
+                        if activated_config_id is None:
+                            try:
+                                task = crud_task.get_task_by_id(
+                                    db_session, inner.task_id
+                                )
+                                task_data = models_task.DeployDeviceTaskSubmission.model_validate(
+                                    task.task_submission_data
+                                )
+                                activated_config_id = task_data.device.identifier
+                            except Exception:
+                                logger.exception(
+                                    "Could not infer activated config id for switch task %s",
+                                    inner.task_id,
+                                )
                         crud_deployment_info.update(
                             db_session,
                             deployment_info[0].id,
+                            deployed_config_id=activated_config_id,
                             deployed_config_commit=inner.config_commit,
                             clear_pending_config_id=True,
                         )

--- a/controller/thymis_controller/network_relay.py
+++ b/controller/thymis_controller/network_relay.py
@@ -411,6 +411,7 @@ class NetworkRelay(nr.NetworkRelay):
                 self.connection_id_to_public_key[connection_id],
                 self.connection_id_to_start_message[connection_id].deployed_config_id,
                 None,
+                preserve_confirmed_switch=True,
             )
 
             deployment_info = crud_deployment_info.update(

--- a/controller/thymis_controller/repo.py
+++ b/controller/thymis_controller/repo.py
@@ -40,7 +40,11 @@ class StateEventHandler(FileSystemEventHandler):
         self.base_path = base_path
         self.notification_manager = notification_manager
         self.last_event = datetime.datetime.min
-        self.event_loop = asyncio.get_event_loop()
+        try:
+            self.event_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self.event_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self.event_loop)
         self.debounce_task = None
         self.paused = False
         self.lock = threading.Lock()

--- a/controller/thymis_controller/routers/api_action.py
+++ b/controller/thymis_controller/routers/api_action.py
@@ -308,26 +308,32 @@ async def switch_config(
                 )
             )
 
+    access_client_token = get_or_create_access_client_token(
+        session, deployment_info_id=deployment_info.id
+    )
     task = task_controller.submit(
-        models.DeployDevicesTaskSubmission(
-            devices=[
-                models.DeployDeviceInformation(
-                    identifier=new_config_id,
-                    source_identifier=deployment_info.deployed_config_id,
-                    deployment_info_id=deployment_info.id,
-                    deployment_public_key=deployment_info.ssh_public_key,
-                    secrets=secrets,
-                )
-            ],
+        models.DeployDeviceTaskSubmission(
+            device=models.DeployDeviceInformation(
+                identifier=new_config_id,
+                source_identifier=deployment_info.deployed_config_id,
+                deployment_info_id=deployment_info.id,
+                deployment_public_key=deployment_info.ssh_public_key,
+                secrets=secrets,
+            ),
             project_path=str(project.path),
             ssh_key_path=str(global_settings.PROJECT_PATH / "id_thymis"),
             known_hosts_path=str(project.known_hosts_path),
             controller_ssh_pubkey=project.public_key,
+            controller_access_client_endpoint=task_controller.access_client_endpoint,
+            access_client_token=access_client_token.token,
             config_commit=project.repo.head_commit(),
         ),
         user_session_id=user_session_id,
         db_session=session,
     )
+    access_client_token.deploy_device_task_id = task.id
+    session.add(access_client_token)
+    session.commit()
 
     return {"message": "config switched and deploy started", "task_id": str(task.id)}
 

--- a/controller/thymis_controller/routers/api_action.py
+++ b/controller/thymis_controller/routers/api_action.py
@@ -16,7 +16,7 @@ from thymis_controller.dependencies import (
     TaskControllerAD,
     UserSessionIDAD,
 )
-from thymis_controller.models.state import State
+from thymis_controller.models.state import Config, State
 
 logger = logging.getLogger(__name__)
 
@@ -248,6 +248,16 @@ async def download_image(
     )
 
 
+THYMIS_DEVICE_MODULE_TYPE = "thymis_controller.modules.thymis.ThymisDevice"
+
+
+def get_config_device_type(config: Config):
+    for module in config.modules:
+        if module.type == THYMIS_DEVICE_MODULE_TYPE:
+            return module.settings.get("device_type")
+    return None
+
+
 @router.post("/action/switch-config")
 async def switch_config(
     deployment_info_id: uuid.UUID,
@@ -268,16 +278,40 @@ async def switch_config(
             detail="Repository is dirty. Please commit your changes first.",
         )
 
+    deployment_info = crud.deployment_info.get_by_id(session, deployment_info_id)
+    if deployment_info is None:
+        raise HTTPException(status_code=404, detail="Deployment info not found")
+
     state = project.read_state()
-    config = next((c for c in state.configs if c.identifier == new_config_id), None)
-    if config is None:
+    source_config = next(
+        (
+            c
+            for c in state.configs
+            if c.identifier == deployment_info.deployed_config_id
+        ),
+        None,
+    )
+    if source_config is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Current config '{deployment_info.deployed_config_id}' not found",
+        )
+
+    target_config = next(
+        (c for c in state.configs if c.identifier == new_config_id), None
+    )
+    if target_config is None:
         raise HTTPException(
             status_code=404, detail=f"Config '{new_config_id}' not found"
         )
 
-    deployment_info = crud.deployment_info.get_by_id(session, deployment_info_id)
-    if deployment_info is None:
-        raise HTTPException(status_code=404, detail="Deployment info not found")
+    source_device_type = get_config_device_type(source_config)
+    target_device_type = get_config_device_type(target_config)
+    if not source_device_type or source_device_type != target_device_type:
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot switch configs with different device types",
+        )
 
     # Reassign the device — pending_config_id communicates the pending state.
     crud.deployment_info.update(
@@ -293,7 +327,7 @@ async def switch_config(
     ):
         return {"message": "config switched; device not connected, skipping deploy"}
 
-    modules = project.get_modules_for_config(state, config)
+    modules = project.get_modules_for_config(state, target_config)
     secrets = []
     for module, settings in modules:
         for secret_type, secret in module.register_secret_settings(settings, project):

--- a/controller/thymis_controller/routers/api_action.py
+++ b/controller/thymis_controller/routers/api_action.py
@@ -16,7 +16,7 @@ from thymis_controller.dependencies import (
     TaskControllerAD,
     UserSessionIDAD,
 )
-from thymis_controller.models.state import Config, State
+from thymis_controller.models.state import State
 
 logger = logging.getLogger(__name__)
 
@@ -248,16 +248,6 @@ async def download_image(
     )
 
 
-THYMIS_DEVICE_MODULE_TYPE = "thymis_controller.modules.thymis.ThymisDevice"
-
-
-def get_config_device_type(config: Config):
-    for module in config.modules:
-        if module.type == THYMIS_DEVICE_MODULE_TYPE:
-            return module.settings.get("device_type")
-    return None
-
-
 @router.post("/action/switch-config")
 async def switch_config(
     deployment_info_id: uuid.UUID,
@@ -305,8 +295,8 @@ async def switch_config(
             status_code=404, detail=f"Config '{new_config_id}' not found"
         )
 
-    source_device_type = get_config_device_type(source_config)
-    target_device_type = get_config_device_type(target_config)
+    source_device_type = source_config.device_type()
+    target_device_type = target_config.device_type()
     if not source_device_type or source_device_type != target_device_type:
         raise HTTPException(
             status_code=400,

--- a/controller/thymis_controller/routers/api_action.py
+++ b/controller/thymis_controller/routers/api_action.py
@@ -257,7 +257,6 @@ async def switch_config(
     task_controller: TaskControllerAD,
     network_relay: NetworkRelayAD,
     user_session_id: UserSessionIDAD,
-    db_session: DBSessionAD,
 ):
     """
     Reassign a deployed device to a different config identifier,
@@ -298,7 +297,7 @@ async def switch_config(
     secrets = []
     for module, settings in modules:
         for secret_type, secret in module.register_secret_settings(settings, project):
-            project.get_secret(db_session, uuid.UUID(secret))
+            project.get_secret(session, uuid.UUID(secret))
             secrets.append(
                 agent.SecretForDevice(
                     secret_id=secret,

--- a/controller/thymis_controller/routers/api_action.py
+++ b/controller/thymis_controller/routers/api_action.py
@@ -248,6 +248,90 @@ async def download_image(
     )
 
 
+@router.post("/action/switch-config")
+async def switch_config(
+    deployment_info_id: uuid.UUID,
+    new_config_id: str,
+    session: DBSessionAD,
+    project: ProjectAD,
+    task_controller: TaskControllerAD,
+    network_relay: NetworkRelayAD,
+    user_session_id: UserSessionIDAD,
+    db_session: DBSessionAD,
+):
+    """
+    Reassign a deployed device to a different config identifier,
+    then immediately deploy the new config to it if the device is connected.
+    """
+    if project.repo.is_dirty():
+        raise HTTPException(
+            status_code=409,
+            detail="Repository is dirty. Please commit your changes first.",
+        )
+
+    state = project.read_state()
+    config = next((c for c in state.configs if c.identifier == new_config_id), None)
+    if config is None:
+        raise HTTPException(
+            status_code=404, detail=f"Config '{new_config_id}' not found"
+        )
+
+    deployment_info = crud.deployment_info.get_by_id(session, deployment_info_id)
+    if deployment_info is None:
+        raise HTTPException(status_code=404, detail="Deployment info not found")
+
+    # Reassign the device — pending_config_id communicates the pending state.
+    crud.deployment_info.update(
+        session,
+        deployment_info_id,
+        pending_config_id=new_config_id,
+    )
+
+    project.update_known_hosts(session)
+
+    if not network_relay.public_key_to_connection_id.get(
+        deployment_info.ssh_public_key
+    ):
+        return {"message": "config switched; device not connected, skipping deploy"}
+
+    modules = project.get_modules_for_config(state, config)
+    secrets = []
+    for module, settings in modules:
+        for secret_type, secret in module.register_secret_settings(settings, project):
+            project.get_secret(db_session, uuid.UUID(secret))
+            secrets.append(
+                agent.SecretForDevice(
+                    secret_id=secret,
+                    path=secret_type.on_device_path,
+                    owner=secret_type.on_device_owner,
+                    group=secret_type.on_device_group,
+                    mode=secret_type.on_device_mode,
+                )
+            )
+
+    task = task_controller.submit(
+        models.DeployDevicesTaskSubmission(
+            devices=[
+                models.DeployDeviceInformation(
+                    identifier=new_config_id,
+                    deployment_info_id=deployment_info.id,
+                    deployment_public_key=deployment_info.ssh_public_key,
+                    secrets=secrets,
+                )
+            ],
+            project_path=str(project.path),
+            ssh_key_path=str(global_settings.PROJECT_PATH / "id_thymis"),
+            known_hosts_path=str(project.known_hosts_path),
+            controller_ssh_pubkey=project.public_key,
+            config_commit=project.repo.head_commit(),
+        ),
+        user_session_id=user_session_id,
+        db_session=session,
+    )
+
+    return {"message": "config switched and deploy started", "task_id": str(task.id)}
+
+
 @router.post("/action/commit")
 def commit(project: ProjectAD, message: str):
     project.repo.add(".")

--- a/controller/thymis_controller/routers/api_action.py
+++ b/controller/thymis_controller/routers/api_action.py
@@ -313,6 +313,7 @@ async def switch_config(
             devices=[
                 models.DeployDeviceInformation(
                     identifier=new_config_id,
+                    source_identifier=deployment_info.deployed_config_id,
                     deployment_info_id=deployment_info.id,
                     deployment_public_key=deployment_info.ssh_public_key,
                     secrets=secrets,

--- a/controller/thymis_controller/routers/api_state.py
+++ b/controller/thymis_controller/routers/api_state.py
@@ -1,12 +1,24 @@
 from typing import Annotated, Optional
 
-from fastapi import APIRouter, BackgroundTasks, Body, Depends, Request
-from thymis_controller import dependencies, models, modules
-from thymis_controller.dependencies import ProjectAD
-from thymis_controller.models.state import State
+from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Request
+from thymis_controller import crud, dependencies, models, modules
+from thymis_controller.dependencies import DBSessionAD, NetworkRelayAD, ProjectAD
+from thymis_controller.models.state import Config, State
 from thymis_controller.repo import RepoStatus
 
 router = APIRouter()
+
+
+def changed_device_type_configs(old_state: State, new_state: State) -> list[Config]:
+    old_configs = {config.identifier: config for config in old_state.configs}
+    changed_configs = []
+
+    for new_config in new_state.configs:
+        old_config = old_configs.get(new_config.identifier)
+        if old_config and old_config.device_type() != new_config.device_type():
+            changed_configs.append(new_config)
+
+    return changed_configs
 
 
 @router.get("/state")
@@ -18,9 +30,26 @@ def get_state(state: State = Depends(dependencies.get_state)):
 def update_state(
     payload: Annotated[dict, Body()],
     project: ProjectAD,
+    db_session: DBSessionAD,
+    network_relay: NetworkRelayAD,
     background_tasks: BackgroundTasks,
 ):
     new_state = State.model_validate(payload)
+    for config in changed_device_type_configs(project.read_state(), new_state):
+        connected_devices = [
+            deployment_info
+            for deployment_info in crud.deployment_info.get_by_config_id(
+                db_session, config.identifier
+            )
+            if network_relay.public_key_to_connection_id.get(
+                deployment_info.ssh_public_key
+            )
+        ]
+        if connected_devices:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Cannot change device type for config '{config.identifier}' while devices are connected",
+            )
     project.write_state(new_state)
     background_tasks.add_task(project.reload_state, new_state)
     return new_state

--- a/controller/thymis_controller/task/executor.py
+++ b/controller/thymis_controller/task/executor.py
@@ -304,6 +304,7 @@ class TaskWorkerPoolManager:
                                         agent.RelayToAgentMessage(
                                             inner=agent.RtESwitchToNewConfigMessage(
                                                 new_path_to_config=message.update.path_to_configuration,
+                                                configuration_id=message.update.configuration_id,
                                                 config_commit=message.update.config_commit,
                                                 task_id=task_id,
                                             )

--- a/controller/thymis_controller/task/worker.py
+++ b/controller/thymis_controller/task/worker.py
@@ -10,6 +10,7 @@ import random
 import shutil
 import signal
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -22,6 +23,15 @@ from pydantic import BaseModel
 from thymis_agent import agent
 from thymis_controller.nix import NIX_CMD, NIX_SSHOPTS
 from thymis_controller.nix.log_parse import NixParser
+
+
+def access_client_proxy_command(
+    endpoint: str, deployment_info_id: uuid.UUID | str
+) -> str:
+    return (
+        f"{sys.executable} -m thymis_controller.access_client "
+        f"{endpoint} {deployment_info_id}"
+    )
 
 
 class ProcessList:
@@ -221,7 +231,7 @@ def deploy_device_task(
             f"-o KbdInteractiveAuthentication=no "
             f"-o ConnectTimeout=10 "
             f"-o BatchMode=yes "
-            f"-o 'ProxyCommand {(os.getenv('PYTHONENV') + '/bin/python') if ('PYTHONENV' in os.environ) else 'python'} -m thymis_controller.access_client {task_data.controller_access_client_endpoint} {task_data.device.deployment_info_id}' "
+            f"-o 'ProxyCommand {access_client_proxy_command(task_data.controller_access_client_endpoint, task_data.device.deployment_info_id)}' "
             "-T",
             "PATH": os.getenv("PATH"),
             "HOME": os.getenv("HOME"),
@@ -627,7 +637,7 @@ def ssh_command_task(
                 "-o",
                 "BatchMode=yes",
                 "-o",
-                f"ProxyCommand={(os.getenv('PYTHONENV') + '/bin/python') if ('PYTHONENV' in os.environ) else 'python'} -m thymis_controller.access_client {task_data.controller_access_client_endpoint} {task_data.deployment_info_id}",
+                f"ProxyCommand={access_client_proxy_command(task_data.controller_access_client_endpoint, task_data.deployment_info_id)}",
                 f"{task_data.target_user}@localhost",
                 task_data.command,
             ],

--- a/controller/thymis_controller/task/worker.py
+++ b/controller/thymis_controller/task/worker.py
@@ -359,6 +359,7 @@ def deploy_device_task(
             models_task.RunnerToControllerTaskUpdate(
                 id=task.id,
                 update=models_task.AgentShouldSwitchToNewConfigurationUpdate(
+                    configuration_id=task_data.device.identifier,
                     deployment_info_id=task_data.device.deployment_info_id,
                     path_to_configuration=config_path,
                     config_commit=task_data.config_commit,

--- a/frontend/src/lib/config/ModuleCard.svelte
+++ b/frontend/src/lib/config/ModuleCard.svelte
@@ -23,6 +23,7 @@
 		showRouting: boolean;
 		canEdit: boolean;
 		artifacts: Artifact[];
+		shouldLockSetting?: (settingKey: string, setting: Setting) => boolean;
 	}
 
 	let {
@@ -33,7 +34,8 @@
 		otherSettings,
 		showRouting,
 		canEdit,
-		artifacts
+		artifacts,
+		shouldLockSetting = () => false
 	}: Props = $props();
 
 	const setSetting = async (setting: Setting<SettingType>, key: string, value: any) => {
@@ -75,6 +77,9 @@
 			!setting.type.extra_data.only_editable_on_target_type.includes(nav.selectedModuleContextType)
 		);
 
+	const canEditSetting = (canEdit: boolean, key: string, setting: Setting) =>
+		canReallyEditSetting(canEdit, setting) && !shouldLockSetting(key, setting);
+
 	const canPaste = (clipboardText: string, setting: Setting<SettingType>) => {
 		if (clipboardText === undefined) return;
 		try {
@@ -112,13 +117,13 @@
 				{$t(setting.displayName)}
 			</P>
 			<div class="flex gap-1">
-				{#key (module.type, globalState.selectedModuleSettings?.settings[key], !canReallyEditSetting(canEdit, setting))}
+				{#key (module.type, globalState.selectedModuleSettings?.settings[key], !canEditSetting(canEdit, key, setting))}
 					<ConfigRenderer
 						key="config-{key}"
 						{setting}
 						moduleSettings={settings}
 						value={globalState.selectedModuleSettings?.settings[key]}
-						disabled={!canReallyEditSetting(canEdit, setting)}
+						disabled={!canEditSetting(canEdit, key, setting)}
 						onChange={(value) => setSetting(setting, key, value)}
 						{artifacts}
 					/>
@@ -135,7 +140,7 @@
 					<Copy size="20" />
 				</button>
 				<Tooltip type="auto">{$t('config.copy')}</Tooltip>
-				{#if canEdit}
+				{#if canEditSetting(canEdit, key, setting)}
 					<button
 						class="m-0 p-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600"
 						onclick={async () => {
@@ -149,7 +154,7 @@
 					</button>
 					<Tooltip type="auto">{$t('config.paste')}</Tooltip>
 				{/if}
-				{#if canEdit}
+				{#if canEditSetting(canEdit, key, setting)}
 					{#if settings?.settings[key] !== undefined}
 						<button
 							class="m-0 p-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600"
@@ -158,7 +163,7 @@
 							<X size="20" />
 						</button>
 						<Tooltip type="auto">{$t('config.clear')}</Tooltip>
-					{:else if canReallyEditSetting(canEdit, setting)}
+					{:else if canEditSetting(canEdit, key, setting)}
 						<button
 							class="m-0 p-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600"
 							onclick={() =>

--- a/frontend/src/lib/deploymentInfo.ts
+++ b/frontend/src/lib/deploymentInfo.ts
@@ -22,6 +22,7 @@ export type DeploymentInfo = {
 	ssh_public_key: string;
 	deployed_config_commit: string | null;
 	deployed_config_id: string | null;
+	pending_config_id: string | null;
 	reachable_deployed_host: string | null;
 	last_seen: string | null;
 	first_seen: string | null;

--- a/frontend/src/lib/taskbar/TaskbarName.svelte
+++ b/frontend/src/lib/taskbar/TaskbarName.svelte
@@ -11,6 +11,23 @@
 	import type { GlobalState } from '$lib/state.svelte';
 	import IdentifierLink from '$lib/IdentifierLink.svelte';
 
+	type DeployDeviceInfo = {
+		identifier?: string;
+		source_identifier?: string | null;
+	};
+
+	type DeployDeviceTaskData = {
+		device?: DeployDeviceInfo;
+	};
+
+	type DeployDevicesTaskData = {
+		devices?: DeployDeviceInfo[];
+	};
+
+	type ConfigurationTaskData = {
+		configuration_id?: string;
+	};
+
 	interface Props {
 		globalState: GlobalState;
 		task: TaskShort;
@@ -26,6 +43,27 @@
 	};
 
 	const iconClass = 'flex-shrink-0';
+
+	const splitSwitchLabel = (label: string) => {
+		const [beforeSource, afterSource = ''] = label.split('{source}');
+		const [between, afterTarget = ''] = afterSource.split('{target}');
+		return { beforeSource, between, afterTarget };
+	};
+
+	const getDeployDevice = (task: TaskShort) => {
+		const submissionData = task.task_submission_data as DeployDeviceTaskData | null | undefined;
+		return submissionData?.device;
+	};
+
+	const getDeployDevices = (task: TaskShort) => {
+		const submissionData = task.task_submission_data as DeployDevicesTaskData | null | undefined;
+		return submissionData?.devices ?? [];
+	};
+
+	const getConfigurationId = (task: TaskShort) => {
+		const submissionData = task.task_submission_data as ConfigurationTaskData | null | undefined;
+		return submissionData?.configuration_id;
+	};
 </script>
 
 <div class="flex gap-2 items-center">
@@ -37,25 +75,65 @@
 		{$t('taskbar.task-types.build_project')}
 	{:else if task.task_type === 'deploy_devices_task'}
 		<Boxes size={iconSize} class={iconClass} />
-		{$t('taskbar.task-types.deploy_devices')}
+		{@const deployDevices = getDeployDevices(task)}
+		{#if deployDevices.length === 1 && deployDevices[0]?.source_identifier}
+			{@const switchLabel = splitSwitchLabel($t('taskbar.task-types.switch_device_config'))}
+			{switchLabel.beforeSource}
+			<IdentifierLink
+				{globalState}
+				identifier={deployDevices[0].source_identifier}
+				context="config"
+				{iconSize}
+			/>
+			{switchLabel.between}
+			<IdentifierLink
+				{globalState}
+				identifier={deployDevices[0].identifier}
+				context="config"
+				{iconSize}
+			/>
+			{switchLabel.afterTarget}
+		{:else}
+			{$t('taskbar.task-types.deploy_devices')}
+		{/if}
 	{:else if task.task_type === 'deploy_device_task'}
 		<Box size={iconSize} class={iconClass} />
-		{@const [before, after] = $t('taskbar.task-types.deploy_device').split('{device}')}
-		{before}
-		<IdentifierLink
-			{globalState}
-			identifier={task.task_submission_data?.device?.identifier}
-			context="config"
-			{iconSize}
-		/>
-		{after}
+		{@const deployDevice = getDeployDevice(task)}
+		{#if deployDevice?.source_identifier}
+			{@const switchLabel = splitSwitchLabel($t('taskbar.task-types.switch_device_config'))}
+			{switchLabel.beforeSource}
+			<IdentifierLink
+				{globalState}
+				identifier={deployDevice.source_identifier}
+				context="config"
+				{iconSize}
+			/>
+			{switchLabel.between}
+			<IdentifierLink
+				{globalState}
+				identifier={deployDevice.identifier}
+				context="config"
+				{iconSize}
+			/>
+			{switchLabel.afterTarget}
+		{:else}
+			{@const [before, after] = $t('taskbar.task-types.deploy_device').split('{device}')}
+			{before}
+			<IdentifierLink
+				{globalState}
+				identifier={deployDevice?.identifier}
+				context="config"
+				{iconSize}
+			/>
+			{after}
+		{/if}
 	{:else if task.task_type === 'build_device_image_task'}
 		<Hammer size={iconSize} class={iconClass} />
 		{@const [before, after] = $t('taskbar.task-types.build_device_image').split('{device}')}
 		{before}
 		<IdentifierLink
 			{globalState}
-			identifier={task.task_submission_data?.configuration_id}
+			identifier={getConfigurationId(task)}
 			context="config"
 			{iconSize}
 		/>
@@ -72,7 +150,7 @@
 		{before}
 		<IdentifierLink
 			{globalState}
-			identifier={task.task_submission_data?.configuration_id}
+			identifier={getConfigurationId(task)}
 			context="config"
 			{iconSize}
 		/>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -461,7 +461,10 @@
 		"refresh-hostkey": "Hostkey Aktualisieren",
 		"edit-tags": "Tags Bearbeiten",
 		"no-deployment-info": "Kein Gerät verbunden",
-		"no-commit": "Keine Commit Info"
+		"no-commit": "Keine Commit Info",
+		"switch-config": "Konfiguration wechseln",
+		"switch-config-select": "Neue Konfiguration wählen...",
+		"switching-to": "Wechselt zu {config}..."
 	},
 	"edit-hostkey": {
 		"create": "Erstellen",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -381,6 +381,7 @@
 			"build_project": "Projekt Bauen",
 			"deploy_devices": "Geräte Ausrollen",
 			"deploy_device": "Gerät Ausrollen: {device}",
+			"switch_device_config": "Wechsel von {source} zu {target}",
 			"build_device_image": "Geräte-Image Bauen: {device}",
 			"ssh_command": "SSH Befehl Ausführen",
 			"run_nixos_vm_task": "NixOS VM für {device} ausführen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -462,7 +462,10 @@
 		"delete-hostkey": "Delete Hostkey",
 		"edit-tags": "Edit Tags",
 		"no-deployment-info": "No devices currently connected",
-		"no-commit": "No commit info"
+		"no-commit": "No commit info",
+		"switch-config": "Switch Config",
+		"switch-config-select": "Select new config...",
+		"switching-to": "Switching to {config}..."
 	},
 	"edit-hostkey": {
 		"title": "Edit Hostkey",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -275,6 +275,7 @@
 			"build_project": "Build Project",
 			"deploy_devices": "Deploy Devices",
 			"deploy_device": "Deploy to {device}",
+			"switch_device_config": "Switch from {source} to {target}",
 			"build_device_image": "Build Image for {device}",
 			"ssh_command": "Run SSH Command",
 			"run_nixos_vm_task": "Run NixOS VM for {device}",

--- a/frontend/src/routes/(authenticated)/configuration/(subpages)/configuration-details/+page.svelte
+++ b/frontend/src/routes/(authenticated)/configuration/(subpages)/configuration-details/+page.svelte
@@ -27,6 +27,7 @@
 			deploymentInfos={data.deploymentInfos}
 			globalState={data.globalState}
 			headCommit={data.headCommit}
+			repoStatus={data.repoStatus}
 		/>
 		<SectionActions class="col-span-1" config={data.nav.selectedConfig} />
 		<SectionConfiguration

--- a/frontend/src/routes/(authenticated)/configuration/(subpages)/configuration-details/SectionDeploymentInfo.svelte
+++ b/frontend/src/routes/(authenticated)/configuration/(subpages)/configuration-details/SectionDeploymentInfo.svelte
@@ -7,11 +7,18 @@
 	import DeploymentInstanceRow, {
 		type ConfigInstance
 	} from '$lib/components/DeploymentInstanceRow.svelte';
+	import { Button, Select } from 'flowbite-svelte';
+	import { fetchWithNotify } from '$lib/fetchWithNotify';
+	import CommitModal from '$lib/repo/CommitModal.svelte';
+	import { invalidateButDeferUntilNavigation } from '$lib/notification';
+	import ArrowRightLeft from 'lucide-svelte/icons/arrow-right-left';
+	import type { RepoStatus } from '$lib/repo/repo';
 
 	interface Props {
 		deploymentInfos?: DeploymentInfo[];
 		globalState: GlobalState;
 		headCommit?: string | null;
+		repoStatus: RepoStatus;
 		class?: string;
 	}
 
@@ -19,6 +26,7 @@
 		deploymentInfos = [],
 		globalState,
 		headCommit = null,
+		repoStatus,
 		class: className = ''
 	}: Props = $props();
 
@@ -42,12 +50,84 @@
 			})
 			.sort((a, b) => Number(b.online) - Number(a.online))
 	);
+
+	// Per-deployment-info switch config state
+	let switchConfigSelections = $state<Record<string, string>>({});
+	let openCommitModal = $state(false);
+	let pendingSwitch: { deploymentInfo: DeploymentInfo; newConfigId: string } | undefined = $state();
+
+	const switchConfig = async (deploymentInfo: DeploymentInfo, newConfigId: string) => {
+		const response = await fetchWithNotify(
+			`/api/action/switch-config?deployment_info_id=${deploymentInfo.id}&new_config_id=${encodeURIComponent(newConfigId)}`,
+			{ method: 'POST' },
+			{ 409: null },
+			undefined,
+			[200, 409]
+		);
+		if (response.status === 409) {
+			pendingSwitch = { deploymentInfo, newConfigId };
+			openCommitModal = true;
+		}
+	};
 </script>
+
+<CommitModal
+	bind:open={openCommitModal}
+	repoStatus={repoStatus}
+	defaultMessage="switch config"
+	onAction={async (message) => {
+		await fetchWithNotify(`/api/action/commit?message=${encodeURIComponent(message)}`, {
+			method: 'POST'
+		});
+		await invalidateButDeferUntilNavigation(
+			(url) => url.pathname === '/api/history' || url.pathname === '/api/repo_status'
+		);
+		if (pendingSwitch) {
+			const { deploymentInfo, newConfigId } = pendingSwitch;
+			pendingSwitch = undefined;
+			await switchConfig(deploymentInfo, newConfigId);
+		}
+	}}
+/>
 
 <Section class={className} title={$t('configuration-details.deployment-info')}>
 	<div class="flex flex-col gap-2 max-w-96">
 		{#each instances as inst (inst.id)}
-			<DeploymentInstanceRow {inst} {globalState} {deploymentInfos} />
+			{@const deploymentInfo = deploymentInfos.find((di) => di.id === inst.id)}
+			{#if deploymentInfo}
+				<DeploymentInstanceRow {inst} {globalState} {deploymentInfos} />
+				{#if deploymentInfo.pending_config_id}
+					{@const pendingConfig = globalState.configs.find(
+						(c) => c.identifier === deploymentInfo.pending_config_id
+					)}
+					<p class="text-sm text-yellow-600 dark:text-yellow-400">
+						{$t('configuration-details.switching-to', {
+							values: { config: pendingConfig?.displayName ?? deploymentInfo.pending_config_id }
+						})}
+					</p>
+				{/if}
+				<div class="flex flex-row items-center gap-2 flex-wrap">
+					<Select
+						class="max-w-xs text-sm"
+						items={globalState.configs
+							.filter((c) => c.identifier !== deploymentInfo.deployed_config_id)
+							.map((c) => ({ name: c.displayName, value: c.identifier }))}
+						bind:value={switchConfigSelections[deploymentInfo.id]}
+						placeholder={$t('configuration-details.switch-config-select')}
+					/>
+					<Button
+						class="px-2 py-1.5 gap-2"
+						color="alternative"
+						disabled={!switchConfigSelections[deploymentInfo.id]}
+						on:click={() => switchConfig(deploymentInfo, switchConfigSelections[deploymentInfo.id])}
+					>
+						<ArrowRightLeft size="16" />
+						{$t('configuration-details.switch-config')}
+					</Button>
+				</div>
+			{/if}
+		{:else}
+			<p class="text-base">{$t('configuration-details.no-deployment-info')}</p>
 		{/each}
 	</div>
 </Section>

--- a/frontend/src/routes/(authenticated)/configuration/(subpages)/configuration-details/SectionDeploymentInfo.svelte
+++ b/frontend/src/routes/(authenticated)/configuration/(subpages)/configuration-details/SectionDeploymentInfo.svelte
@@ -73,7 +73,7 @@
 
 <CommitModal
 	bind:open={openCommitModal}
-	repoStatus={repoStatus}
+	{repoStatus}
 	defaultMessage="switch config"
 	onAction={async (message) => {
 		await fetchWithNotify(`/api/action/commit?message=${encodeURIComponent(message)}`, {

--- a/frontend/src/routes/(authenticated)/configuration/(subpages)/configuration-details/SectionDeploymentInfo.svelte
+++ b/frontend/src/routes/(authenticated)/configuration/(subpages)/configuration-details/SectionDeploymentInfo.svelte
@@ -13,6 +13,7 @@
 	import { invalidateButDeferUntilNavigation } from '$lib/notification';
 	import ArrowRightLeft from 'lucide-svelte/icons/arrow-right-left';
 	import type { RepoStatus } from '$lib/repo/repo';
+	import { getDeviceType } from '$lib/config/configUtils';
 
 	interface Props {
 		deploymentInfos?: DeploymentInfo[];
@@ -55,6 +56,21 @@
 	let switchConfigSelections = $state<Record<string, string>>({});
 	let openCommitModal = $state(false);
 	let pendingSwitch: { deploymentInfo: DeploymentInfo; newConfigId: string } | undefined = $state();
+
+	const switchableConfigsFor = (deploymentInfo: DeploymentInfo) => {
+		const sourceConfig = globalState.configs.find(
+			(c) => c.identifier === deploymentInfo.deployed_config_id
+		);
+		const sourceDeviceType = getDeviceType(sourceConfig);
+		if (!sourceDeviceType) {
+			return [];
+		}
+
+		return globalState.configs.filter(
+			(c) =>
+				c.identifier !== deploymentInfo.deployed_config_id && getDeviceType(c) === sourceDeviceType
+		);
+	};
 
 	const switchConfig = async (deploymentInfo: DeploymentInfo, newConfigId: string) => {
 		const response = await fetchWithNotify(
@@ -109,9 +125,10 @@
 				<div class="flex flex-row items-center gap-2 flex-wrap">
 					<Select
 						class="max-w-xs text-sm"
-						items={globalState.configs
-							.filter((c) => c.identifier !== deploymentInfo.deployed_config_id)
-							.map((c) => ({ name: c.displayName, value: c.identifier }))}
+						items={switchableConfigsFor(deploymentInfo).map((c) => ({
+							name: c.displayName,
+							value: c.identifier
+						}))}
 						bind:value={switchConfigSelections[deploymentInfo.id]}
 						placeholder={$t('configuration-details.switch-config-select')}
 					/>

--- a/frontend/src/routes/(authenticated)/configuration/(subpages)/edit/+page.svelte
+++ b/frontend/src/routes/(authenticated)/configuration/(subpages)/edit/+page.svelte
@@ -3,7 +3,7 @@
 	import { Card } from 'flowbite-svelte';
 	import ModuleList from '$lib/config/ModuleList.svelte';
 	import { getTagByIdentifier } from '$lib/state';
-	import type { ModuleSettingsWithOrigin, Tag, Config, Module, Origin } from '$lib/state';
+	import type { ModuleSettingsWithOrigin, Tag, Config, Module, Origin, Setting } from '$lib/state';
 	import type { PageData } from './$types';
 	import ModuleCard from '$lib/config/ModuleCard.svelte';
 
@@ -53,6 +53,18 @@
 	const getOtherSettings = (target: Config | Tag | undefined, module: Module | undefined) => {
 		return getModuleSettings(target)?.filter((s) => s.type === module?.type);
 	};
+
+	const selectedConfigHasConnectedDevices = () =>
+		data.connectedDeploymentInfos.some(
+			(deploymentInfo) =>
+				deploymentInfo.deployed_config_id === data.nav.selectedModuleContextIdentifier
+		);
+
+	const shouldLockSetting = (settingKey: string, setting: Setting) =>
+		data.nav.selectedModuleContextType === 'config' &&
+		data.nav.selectedModule?.type === 'thymis_controller.modules.thymis.ThymisDevice' &&
+		settingKey === 'device_type' &&
+		selectedConfigHasConnectedDevices();
 </script>
 
 <div class="grid grid-flow-row grid-cols-1 md:grid-cols-[250px_auto] gap-4">
@@ -89,6 +101,7 @@
 			showRouting={data.nav.selectedTargetType === 'config'}
 			canEdit={data.nav.selectedTarget === data.nav.selectedModuleContext}
 			artifacts={data.artifacts}
+			{shouldLockSetting}
 		/>
 	{/if}
 </div>


### PR DESCRIPTION
Add `pending_config_id` to `deployment_info` as a UI-only indicator that a config switch is in flight.

## Changes

- **`POST /api/action/switch-config`** — sets `pending_config_id` on the target deployment_info, then immediately triggers a deploy if the device is connected
- **`EtRSwitchToNewConfigResultMessage` handler** — clears `pending_config_id` on successful activation; device self-reports the new `deployed_config_id` on reconnect
- **`/action/deploy`** — unchanged; routes by `deployment_info_id` + `deployed_config_id` as before
- **`SectionDeploymentInfo`** — shows a "Switching to \<config\>..." badge when `pending_config_id` is set; per-device select + Switch Config button to initiate a switch
- **Migration `b1c2d3e4f5a6`** — adds nullable `pending_config_id` column to `deployment_info`