### PR TITLE
Fix stale config switch pending state

### DIFF
--- a/controller/tests/routes/test_switch_config_api.py
+++ b/controller/tests/routes/test_switch_config_api.py
@@ -215,8 +215,10 @@ def switch_test_client(monkeypatch):
 class TestSwitchConfigAPI:
     """Exercise POST /api/action/switch-config through the HTTP layer."""
 
-    def test_switch_config_sets_pending(self, switch_test_client):
-        """Switching sets pending_config_id; device is NOT connected so deploy is skipped."""
+    def test_switch_config_offline_device_does_not_set_pending(
+        self, switch_test_client
+    ):
+        """Offline devices cannot have an in-flight switch, so pending stays clear."""
         client = switch_test_client
         project = client._project
         _write_state(project, [_make_config("config-a"), _make_config("config-b")])
@@ -228,12 +230,11 @@ class TestSwitchConfigAPI:
             "/api/action/switch-config",
             params={"deployment_info_id": dep_id, "new_config_id": "config-b"},
         )
-        assert resp.status_code == 200
-        body = resp.json()
-        assert "not connected" in body["message"]
+        assert resp.status_code == 409
+        assert "Device is offline" in resp.json()["detail"]
 
         updated = _get_deployment_info(client, dep_id)
-        assert updated["pending_config_id"] == "config-b"
+        assert updated["pending_config_id"] is None
         assert updated["deployed_config_id"] == "config-a"
         assert len(client._fake_task_controller.submissions) == 0
 
@@ -289,6 +290,25 @@ class TestSwitchConfigAPI:
         assert updated["pending_config_id"] is None
         assert len(client._fake_task_controller.submissions) == 0
 
+    def test_switch_config_connected_task_submission_sets_pending(
+        self, switch_test_client
+    ):
+        client = switch_test_client
+        _write_state(
+            client._project, [_make_config("config-a"), _make_config("config-b")]
+        )
+        dep = _create_deployment_info(client, "config-a", ssh_public_key="ssh-key-1")
+        client._fake_network_relay.public_key_to_connection_id["ssh-key-1"] = "conn-1"
+
+        resp = client.post(
+            "/api/action/switch-config",
+            params={"deployment_info_id": dep["id"], "new_config_id": "config-b"},
+        )
+
+        assert resp.status_code == 200
+        updated = _get_deployment_info(client, dep["id"])
+        assert updated["pending_config_id"] == "config-b"
+
     def test_switch_config_missing_config_returns_404(self, switch_test_client):
         client = switch_test_client
         _write_state(client._project, [_make_config("config-a")])
@@ -343,6 +363,9 @@ class TestSwitchConfigAPI:
         dep = _create_deployment_info(client, "config-a")
         assert dep["pending_config_id"] is None
 
+        client._fake_network_relay.public_key_to_connection_id[
+            dep["ssh_public_key"]
+        ] = "conn-1"
         client.post(
             "/api/action/switch-config",
             params={"deployment_info_id": dep["id"], "new_config_id": "config-b"},
@@ -360,6 +383,9 @@ class TestSwitchConfigAPI:
 
         dep = _create_deployment_info(client, "config-a")
 
+        client._fake_network_relay.public_key_to_connection_id[
+            dep["ssh_public_key"]
+        ] = "conn-1"
         client.post(
             "/api/action/switch-config",
             params={"deployment_info_id": dep["id"], "new_config_id": "config-b"},

--- a/controller/tests/task/test_switch_task_failure.py
+++ b/controller/tests/task/test_switch_task_failure.py
@@ -1,0 +1,77 @@
+import uuid
+from datetime import datetime, timezone
+from multiprocessing import Pipe
+
+from thymis_controller import crud, db_models, models
+from thymis_controller.models import task as task_models
+from thymis_controller.task.executor import TaskWorkerPoolManager
+
+
+class FakeController:
+    pass
+
+
+def _make_switch_task(db_session, deployment_info_id):
+    task_data = models.DeployDeviceTaskSubmission(
+        device=models.DeployDeviceInformation(
+            identifier="config-b",
+            source_identifier="config-a",
+            deployment_info_id=deployment_info_id,
+            deployment_public_key="key-a",
+            secrets=[],
+        ),
+        project_path="/project",
+        ssh_key_path="/project/id_thymis",
+        known_hosts_path="/tmp/known_hosts",
+        controller_ssh_pubkey="controller-key",
+        controller_access_client_endpoint="ws://127.0.0.1:8080/agent/relay_for_clients",
+        access_client_token="token",
+        config_commit="commit-b",
+    )
+    task = db_models.Task(
+        id=uuid.uuid4(),
+        start_time=datetime.now(timezone.utc),
+        state="running",
+        task_type=task_data.type,
+        user_session_id=uuid.uuid4(),
+        task_submission_data=task_data.model_dump(mode="json"),
+    )
+    db_session.add(task)
+    db_session.commit()
+    return task
+
+
+def test_failed_switch_task_clears_pending_config_id(db_session):
+    deployment_info = crud.deployment_info.create(
+        db_session,
+        ssh_public_key="key-a",
+        deployed_config_id="config-a",
+    )
+    crud.deployment_info.update(
+        db_session,
+        deployment_info.id,
+        pending_config_id="config-b",
+    )
+    task = _make_switch_task(db_session, deployment_info.id)
+
+    executor = TaskWorkerPoolManager(FakeController())
+    executor._db_engine = db_session.bind
+    controller_side, worker_side = Pipe()
+    worker_side.send(
+        task_models.RunnerToControllerTaskUpdate(
+            id=task.id,
+            update=task_models.TaskFailedUpdate(reason="Agent failed to switch"),
+        )
+    )
+    worker_side.close()
+    executor.futures[task.id] = (None, controller_side)
+
+    executor.listen_child_messages(controller_side, task.id)
+    db_session.expire_all()
+
+    updated = crud.deployment_info.get_by_id(db_session, deployment_info.id)
+    failed_task = crud.task.get_task_by_id(db_session, task.id)
+    assert updated.pending_config_id is None
+    assert updated.deployed_config_id == "config-a"
+    assert failed_task.state == "failed"
+    assert "Agent failed to switch" in failed_task.exception

--- a/controller/thymis_controller/routers/api_action.py
+++ b/controller/thymis_controller/routers/api_action.py
@@ -303,7 +303,16 @@ async def switch_config(
             detail="Cannot switch configs with different device types",
         )
 
-    # Reassign the device — pending_config_id communicates the pending state.
+    if not network_relay.public_key_to_connection_id.get(
+        deployment_info.ssh_public_key
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail="Device is offline. Cannot switch config until it is connected.",
+        )
+
+    # Reassign the device only after we know a deploy task can be submitted.
+    # pending_config_id reflects an in-flight switch, not a queued offline intent.
     crud.deployment_info.update(
         session,
         deployment_info_id,
@@ -311,11 +320,6 @@ async def switch_config(
     )
 
     project.update_known_hosts(session)
-
-    if not network_relay.public_key_to_connection_id.get(
-        deployment_info.ssh_public_key
-    ):
-        return {"message": "config switched; device not connected, skipping deploy"}
 
     modules = project.get_modules_for_config(state, target_config)
     secrets = []

--- a/controller/thymis_controller/task/executor.py
+++ b/controller/thymis_controller/task/executor.py
@@ -230,6 +230,20 @@ class TaskWorkerPoolManager:
                                 conn.close()
                                 break
                             case models_task.TaskFailedUpdate(reason=reason):
+                                submission_data = task.task_submission_data or {}
+                                device = submission_data.get("device", {})
+                                deployment_info_id = device.get("deployment_info_id")
+                                source_identifier = device.get("source_identifier")
+                                if (
+                                    task.task_type == "deploy_device_task"
+                                    and source_identifier
+                                    and deployment_info_id
+                                ):
+                                    crud.deployment_info.update(
+                                        db_session,
+                                        uuid.UUID(deployment_info_id),
+                                        pending_config_id=None,
+                                    )
                                 task.state = "failed"
                                 task.add_exception(reason)
                                 task.end_time = datetime.now(timezone.utc)

--- a/frontend/src/routes/(authenticated)/configuration/(subpages)/configuration-details/SectionDeploymentInfo.svelte
+++ b/frontend/src/routes/(authenticated)/configuration/(subpages)/configuration-details/SectionDeploymentInfo.svelte
@@ -116,35 +116,38 @@
 					<div class="flex flex-col gap-2 max-w-96 mr-4">
 						<DeploymentInstanceRow {inst} {globalState} {deploymentInfos} />
 					</div>
-					<Select
-						class="max-w-xs text-sm"
-						items={switchableConfigsFor(deploymentInfo).map((c) => ({
-							name: c.displayName,
-							value: c.identifier
-						}))}
-						bind:value={switchConfigSelections[deploymentInfo.id]}
-						placeholder={$t('configuration-details.switch-config-select')}
-					/>
-					<Button
-						class="px-2 py-1.5 gap-2"
-						color="alternative"
-						disabled={!switchConfigSelections[deploymentInfo.id]}
-						on:click={() => switchConfig(deploymentInfo, switchConfigSelections[deploymentInfo.id])}
-					>
-						<ArrowRightLeft size="16" />
-						{$t('configuration-details.switch-config')}
-					</Button>
-					{#if deploymentInfo.pending_config_id}
-						{@const [before, after] = $t('configuration-details.switching-to').split('{config}')}
-						<div class="text-sm text-yellow-600 dark:text-yellow-400 flex items-center gap-1">
-							{before}
-							<IdentifierLink
-								{globalState}
-								identifier={deploymentInfo.pending_config_id}
-								context="config"
-							/>
-							{after}
-						</div>
+					{#if inst.online}
+						<Select
+							class="max-w-xs text-sm"
+							items={switchableConfigsFor(deploymentInfo).map((c) => ({
+								name: c.displayName,
+								value: c.identifier
+							}))}
+							bind:value={switchConfigSelections[deploymentInfo.id]}
+							placeholder={$t('configuration-details.switch-config-select')}
+						/>
+						<Button
+							class="px-2 py-1.5 gap-2"
+							color="alternative"
+							disabled={!switchConfigSelections[deploymentInfo.id]}
+							on:click={() =>
+								switchConfig(deploymentInfo, switchConfigSelections[deploymentInfo.id])}
+						>
+							<ArrowRightLeft size="16" />
+							{$t('configuration-details.switch-config')}
+						</Button>
+						{#if deploymentInfo.pending_config_id}
+							{@const [before, after] = $t('configuration-details.switching-to').split('{config}')}
+							<div class="text-sm text-yellow-600 dark:text-yellow-400 flex items-center gap-1">
+								{before}
+								<IdentifierLink
+									{globalState}
+									identifier={deploymentInfo.pending_config_id}
+									context="config"
+								/>
+								{after}
+							</div>
+						{/if}
 					{/if}
 				{/if}
 			</div>


### PR DESCRIPTION
## Summary
- Do not mark config switches as pending for offline devices
- Clear pending switch state when the switch deploy task fails
- Add API/task coverage for offline and failed switch behavior

## Tests
- env -u RUNNING_IN_PLAYWRIGHT .venv/bin/python -m pytest -sxv tests/routes/test_switch_config_api.py tests/crud/test_switch_config.py tests/routes/test_switch_config_activation.py tests/task/test_switch_task_failure.py --timeout=30

Stacked on #709.