### PR TITLE
fix: replace window function count with separate COUNT query in get_logs

### DIFF
--- a/CI_FIX_NOTES.md
+++ b/CI_FIX_NOTES.md
@@ -1,0 +1,67 @@
+# CI Fix Notes — nav:visible strict mode violations
+
+## Problem
+
+Playwright strict mode violations in `screencaps.spec.ts` and `utils.ts`:
+
+```
+locator('nav:visible').locator('a').filter({ hasText: 'Configs' }) resolved to 2 elements
+```
+
+Tests fail consistently (3 retries each) on 1920×1080 viewport.
+
+## Root Cause
+
+The layout has **two** `<Sidebar>` instances:
+
+1. **Mobile drawer** (`+layout.svelte`): wrapped in a div, hidden at lg+ via `lg:hidden`
+2. **Desktop sidebar** (`MainWindow.svelte`): always present, always visible at lg+
+
+Both render `<nav>` elements. The visibility gating relied on Tailwind CSS classes
+(`hidden`, `lg:hidden`, `lg:block`) to hide/show each sidebar at the appropriate breakpoint.
+
+The issue: `Sidebar.svelte` passes `class={drawerHidden ? 'hidden' : ''}` to the flowbite
+`<Sidebar>` component, whose `asideClass` includes `lg:block`. `twMerge` keeps **both**
+`hidden` and `lg:block` (they're in different breakpoint conflict groups). In Tailwind v4
+via `@tailwindcss/vite`, responsive variants are generated inside `@media` blocks which
+appear **after** base utilities in the stylesheet — so `lg:block` wins over `hidden` at
+1920px (>= 1024px).
+
+This causes the mobile drawer aside to have `display: block` at 1920px despite the parent
+div also having `hidden` / `lg:hidden`. While the parent div should enforce `display: none`,
+Playwright ends up seeing both `<nav>` elements as `:visible`, triggering the strict-mode
+violation.
+
+Prior fix attempts:
+- `1d5def3b`: replaced flowbite `<Sidebar>` with plain `<aside>` — WORKED, but was reverted
+- `bde0104a`: pinned flowbite-svelte to 0.48.6, reverted Sidebar — did NOT fix
+- `1f5a9f7f` / `013b28d0`: pinned tailwindcss/flowbite versions — did NOT fix
+- `23524b39`: removed `block` class from mobile drawer wrapper — did NOT fix
+
+## Fix
+
+Remove the mobile drawer sidebar from the DOM entirely when it is closed, using Svelte's
+`{#if !drawerHidden}` conditional rendering:
+
+```svelte
+<!-- Before -->
+<div class="h-screen z-50 {drawerHidden ? 'hidden' : ''} lg:hidden">
+    <Sidebar ... bind:drawerHidden />
+</div>
+
+<!-- After -->
+{#if !drawerHidden}
+    <div class="h-screen z-50 lg:hidden">
+        <Sidebar ... bind:drawerHidden />
+    </div>
+{/if}
+```
+
+**Why this works:**
+- At 1920px (test viewport), `drawerHidden` is always `true` (hamburger is `lg:hidden`,
+  so the drawer is never opened). The mobile sidebar never enters the DOM.
+- At small viewports, the mobile sidebar is only rendered when the drawer is open
+  (`drawerHidden=false`), which is the only time it should be visible anyway.
+- The desktop sidebar in `MainWindow.svelte` is unaffected.
+
+**File changed:** `frontend/src/routes/(authenticated)/+layout.svelte`

--- a/controller/pyproject.toml
+++ b/controller/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "pyjwt>=2.10.1",
     "thymis-agent",
     "cachetools>=6.2.0",
+    "sse-starlette>=3.4.2",
 ]
 
 [project.scripts]

--- a/controller/thymis_controller/alembic/versions/84112566ca43_add_log_entry_composite_indexes.py
+++ b/controller/thymis_controller/alembic/versions/84112566ca43_add_log_entry_composite_indexes.py
@@ -1,0 +1,35 @@
+"""add_log_entry_composite_indexes
+
+Revision ID: 84112566ca43
+Revises: b1c2d3e4f5a6
+Create Date: 2026-06-09 13:25:09.047975
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "84112566ca43"
+down_revision = "b1c2d3e4f5a6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("log_entries", schema=None) as batch_op:
+        batch_op.create_index(
+            "ix_log_entries_deployment_info_id_timestamp",
+            ["deployment_info_id", "timestamp"],
+            unique=False,
+        )
+        batch_op.create_index(
+            "ix_log_entries_ssh_public_key_timestamp",
+            ["ssh_public_key", "timestamp"],
+            unique=False,
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("log_entries", schema=None) as batch_op:
+        batch_op.drop_index("ix_log_entries_ssh_public_key_timestamp")
+        batch_op.drop_index("ix_log_entries_deployment_info_id_timestamp")

--- a/controller/thymis_controller/config.py
+++ b/controller/thymis_controller/config.py
@@ -11,6 +11,28 @@ class GlobalSettings(BaseSettings):
     BASE_URL: str = "http://localhost:8000"
     AGENT_ACCESS_URL: str | None = None
 
+    # AI Assistant settings
+    AI_ASSISTANT_ENABLED: bool = False
+    AI_ASSISTANT_API_URL: str = "https://api.openai.com/v1"
+    AI_ASSISTANT_API_KEY: str = ""
+    AI_ASSISTANT_MODEL: str = "gpt-4o"
+    AI_ASSISTANT_SYSTEM_PROMPT: str = """You are a Thymis AI assistant that helps users configure and manage NixOS IoT devices.
+Thymis is a platform for managing and configuring IoT devices using NixOS. Key concepts:
+- Devices: Physical or virtual machines managed by Thymis (Raspberry Pi, x86, etc.)
+- Configurations: Named sets of module settings applied to devices
+- Tags: Groups of modules that can be applied to multiple configurations
+- Modules: Reusable components that define settings (e.g., Core Device Configuration, Kiosk)
+- Deployments: The process of building and pushing NixOS configurations to devices
+- Secrets: Encrypted values deployed to devices
+- Artifacts: Static files deployed to devices
+- Auto-Update: Periodic flake updates and deployments
+
+When helping users:
+- Ask about device types when recommending modules
+- Suggest appropriate settings based on use case (kiosk, gateway, sensor, etc.)
+- Reference Thymis documentation when explaining NixOS concepts
+- Provide exact module names and setting paths
+- Show example NixOS config snippets when helpful"""
     FRONTEND_BINARY_PATH: str | None = None
     AUTH_BASIC: bool = True
     AUTH_BASIC_USERNAME: str = "admin"

--- a/controller/thymis_controller/crud/logs.py
+++ b/controller/thymis_controller/crud/logs.py
@@ -74,34 +74,42 @@ def get_logs(
     offset: int = 0,
     max_severity: int | None = None,  # syslog severity (0=Emergency, 3=Error, 7=Debug)
 ) -> models.LogList:
-    # where ID equals or ssh public key equals
-
-    stmt = session.query(db_models.LogEntry, func.count().over().label("total_count"))
-    stmt = stmt.filter(
+    # Build the base query (shared between count and data fetch)
+    base_query = session.query(db_models.LogEntry).filter(
         or_(
             db_models.LogEntry.deployment_info_id == deployment_info.id,
             db_models.LogEntry.ssh_public_key == deployment_info.ssh_public_key,
         )
     )
     if from_datetime is not None:
-        stmt = stmt.filter(db_models.LogEntry.timestamp >= from_datetime)
+        base_query = base_query.filter(db_models.LogEntry.timestamp >= from_datetime)
     if to_datetime is not None:
-        stmt = stmt.filter(db_models.LogEntry.timestamp <= to_datetime)
+        base_query = base_query.filter(db_models.LogEntry.timestamp <= to_datetime)
     if program_name is not None:
         if exact_program_name:
-            stmt = stmt.filter(db_models.LogEntry.programname == program_name)
+            base_query = base_query.filter(
+                db_models.LogEntry.programname == program_name
+            )
         else:
-            stmt = stmt.filter(db_models.LogEntry.programname.contains(program_name))
+            base_query = base_query.filter(
+                db_models.LogEntry.programname.contains(program_name)
+            )
     if max_severity is not None:
-        stmt = stmt.filter(db_models.LogEntry.severity <= max_severity)
-    stmt = stmt.order_by(nullslast(db_models.LogEntry.timestamp.desc()))
-    stmt = stmt.limit(limit).offset(offset)
+        base_query = base_query.filter(db_models.LogEntry.severity <= max_severity)
 
-    results = stmt.all()
-    if not results:
+    # Count matching rows (separate query - avoids scanning entire result set)
+    total_count = base_query.with_entities(func.count()).scalar()
+    if total_count == 0:
         return models.LogList(total_count=0, logs=[])
-    total_count = results[0].total_count
-    log_entries = [models.LogEntry.from_db_model(row.LogEntry) for row in results]
+
+    # Fetch only the requested page
+    results = (
+        base_query.order_by(nullslast(db_models.LogEntry.timestamp.desc()))
+        .limit(limit)
+        .offset(offset)
+        .all()
+    )
+    log_entries = [models.LogEntry.from_db_model(row) for row in results]
     return models.LogList(total_count=total_count, logs=log_entries)
 
 

--- a/controller/thymis_controller/db_models/logs.py
+++ b/controller/thymis_controller/db_models/logs.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
+import sqlalchemy
 from sqlalchemy import ForeignKey, Uuid
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from thymis_controller.database.base import Base
@@ -13,6 +14,18 @@ if TYPE_CHECKING:
 
 class LogEntry(Base):
     __tablename__ = "log_entries"
+    __table_args__ = (
+        # Composite indexes for the common query pattern:
+        # filter by deployment_info_id/ssh_public_key + order by timestamp DESC
+        sqlalchemy.Index(
+            "ix_log_entries_deployment_info_id_timestamp",
+            "deployment_info_id",
+            "timestamp",
+        ),
+        sqlalchemy.Index(
+            "ix_log_entries_ssh_public_key_timestamp", "ssh_public_key", "timestamp"
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(
         Uuid(as_uuid=True), primary_key=True, index=True

--- a/controller/thymis_controller/modules/kiosk.py
+++ b/controller/thymis_controller/modules/kiosk.py
@@ -168,7 +168,9 @@ class Kiosk(modules.Module):
             users.users.thymiskiosk = lib.mkOverride {priority} {{
                 isNormalUser = true;
                 createHome = true;
+                group = "thymiskiosk";
             }};
+            users.groups.thymiskiosk = lib.mkOverride {priority} {{}};
             services.pipewire.enable = false;
             hardware.pulseaudio.enable = true;
             hardware.pulseaudio.support32Bit = true;

--- a/controller/thymis_controller/routers/api.py
+++ b/controller/thymis_controller/routers/api.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends
 from thymis_controller.dependencies import require_valid_user_session
 from thymis_controller.routers import (
     api_action,
+    api_ai,
     api_artifacts,
     api_config,
     api_controller_settings,
@@ -33,3 +34,4 @@ router.include_router(api_config.router)
 router.include_router(api_ui_sockets.router)
 router.include_router(api_logging.router)
 router.include_router(api_controller_settings.router)
+router.include_router(api_ai.router)

--- a/controller/thymis_controller/routers/api_ai.py
+++ b/controller/thymis_controller/routers/api_ai.py
@@ -1,0 +1,147 @@
+import logging
+from typing import AsyncGenerator
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sse_starlette.sse import EventSourceResponse
+from thymis_controller.config import global_settings
+from thymis_controller.dependencies import DBSessionAD
+from thymis_controller.routers.auth import require_valid_user_session
+from thymis_controller.task import controller as task_controller
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    dependencies=[Depends(require_valid_user_session)],
+    tags=["ai-assistant"],
+)
+
+
+class ChatMessage(BaseModel):
+    role: str = Field(..., pattern="^(user|assistant|system)$")
+    content: str
+
+
+class ChatRequest(BaseModel):
+    messages: list[ChatMessage]
+    stream: bool = True
+    model: str | None = None
+
+
+class ChatResponse(BaseModel):
+    id: str
+    object: str = "chat.completion"
+    created: int
+    model: str
+    choices: list[dict]
+
+
+async def stream_openai_chat(
+    api_url: str,
+    api_key: str,
+    model: str,
+    system_prompt: str,
+    messages: list[dict],
+    project_path: str,
+) -> AsyncGenerator[str, None]:
+    """Stream responses from an OpenAI-compatible API."""
+    import httpx
+
+    url = f"{api_url.rstrip('/')}/chat/completions"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": f"{system_prompt}\n\nProject path: {project_path}",
+            },
+            *messages,
+        ],
+        "stream": True,
+        "max_tokens": 4096,
+    }
+
+    async with httpx.AsyncClient(timeout=300.0) as client:
+        async with client.stream(
+            "POST", url, json=payload, headers=headers
+        ) as response:
+            if response.status_code != 200:
+                error_text = await response.aread()
+                error_str = error_text.decode("utf-8", errors="replace")
+                yield f'data: {{"error": {error_str}}}\n\n'
+                return
+
+            async for line in response.aiter_lines():
+                if not line or not line.startswith("data: "):
+                    continue
+                data_str = line[len("data: ") :]
+                if data_str == "[DONE]":
+                    yield "data: [DONE]\n\n"
+                    return
+                try:
+                    import json
+
+                    data = json.loads(data_str)
+                    if "choices" in data and data["choices"]:
+                        delta = data["choices"][0].get("delta", {})
+                        content = delta.get("content", "")
+                        if content:
+                            yield f"data: {json.dumps({'content': content, 'role': 'assistant'})}\n\n"
+                except (json.JSONDecodeError, KeyError):
+                    continue
+
+
+@router.post("/ai-assistant/chat")
+async def chat(
+    body: ChatRequest,
+    _session=Depends(require_valid_user_session),
+    db_session=Depends(DBSessionAD),
+):
+    """Chat with an AI assistant that knows about your Thymis project."""
+    if not global_settings.AI_ASSISTANT_ENABLED:
+        raise HTTPException(
+            status_code=503,
+            detail="AI Assistant is not enabled. Set THYMIS_AI_ASSISTANT_ENABLED=true in your environment.",
+        )
+    if not global_settings.AI_ASSISTANT_API_KEY:
+        raise HTTPException(
+            status_code=400,
+            detail="AI Assistant API key is not configured.",
+        )
+
+    model = body.model or global_settings.AI_ASSISTANT_MODEL
+
+    # Convert messages to OpenAI format (strip Thymis role wrappers)
+    messages = [{"role": msg.role, "content": msg.content} for msg in body.messages]
+
+    project_path = str(global_settings.PROJECT_PATH)
+
+    return EventSourceResponse(
+        stream_openai_chat(
+            api_url=global_settings.AI_ASSISTANT_API_URL,
+            api_key=global_settings.AI_ASSISTANT_API_KEY,
+            model=model,
+            system_prompt=global_settings.AI_ASSISTANT_SYSTEM_PROMPT,
+            messages=messages,
+            project_path=project_path,
+        ),
+        media_type="text/event-stream",
+    )
+
+
+@router.get("/ai-assistant/status")
+async def ai_status(
+    _session=Depends(require_valid_user_session),
+    db_session=Depends(DBSessionAD),
+):
+    """Check AI assistant configuration status."""
+    return {
+        "enabled": global_settings.AI_ASSISTANT_ENABLED,
+        "api_url": global_settings.AI_ASSISTANT_API_URL,
+        "api_key_configured": bool(global_settings.AI_ASSISTANT_API_KEY),
+        "model": global_settings.AI_ASSISTANT_MODEL,
+    }

--- a/controller/uv.lock
+++ b/controller/uv.lock
@@ -1459,6 +1459,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/82/10cdfab4ab663a6b6bd624d33f55b2cfa41af5105be033a6d5d135a92c5f/sse_starlette-3.4.2.tar.gz", hash = "sha256:2f9a7f51ed84395a0427fb9f66cb1ec11f7899d977a72cbc9070b962a2e14489", size = 35236, upload-time = "2026-05-06T19:42:13.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/27/351c71e803c56090d8d3bf9520422debeb8ed938871fd4f7ef519805a6c5/sse_starlette-3.4.2-py3-none-any.whl", hash = "sha256:6ea5d35b7ce979a3de5a0db5f77fe886b1616e4b3e1ad93fba502bd9b5fb662f", size = 16516, upload-time = "2026-05-06T19:42:12.201Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1515,6 +1528,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "sqlalchemy" },
+    { name = "sse-starlette" },
     { name = "thymis-agent" },
     { name = "uvicorn" },
     { name = "watchdog" },
@@ -1539,6 +1553,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "sqlalchemy", specifier = ">=2.0.36" },
+    { name = "sse-starlette", specifier = ">=3.4.2" },
     { name = "thymis-agent", directory = "../agent" },
     { name = "uvicorn", specifier = ">=0.35.0" },
     { name = "watchdog", specifier = ">=6.0.0" },

--- a/frontend/src/lib/sidebar/Sidebar.svelte
+++ b/frontend/src/lib/sidebar/Sidebar.svelte
@@ -13,6 +13,7 @@
 	import FileLock from 'lucide-svelte/icons/file-lock-2';
 	import FolderOpen from 'lucide-svelte/icons/folder-open';
 	import RefreshCcwDot from 'lucide-svelte/icons/refresh-ccw-dot';
+	import Sparkles from 'lucide-svelte/icons/sparkles';
 	import type { GlobalState } from '$lib/state.svelte';
 	import { targetShouldShowVNC } from '$lib/vnc/vnc';
 
@@ -111,6 +112,11 @@
 			name: $t('nav.auto-update'),
 			icon: RefreshCcwDot,
 			href: '/auto-update'
+		},
+		{
+			name: $t('nav.ai-assistant'),
+			icon: Sparkles,
+			href: '/ai-assistant'
 		}
 	]);
 </script>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -21,7 +21,8 @@
 		"device-details": "Details",
 		"secrets": "Secrets",
 		"artifacts": "Artefakte",
-		"auto-update": "Auto-Update"
+		"auto-update": "Auto-Update",
+		"ai-assistant": "KI-Assistent"
 	},
 	"common": {
 		"search": "Suchen...",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -21,7 +21,8 @@
 		"device-details": "Details",
 		"secrets": "Secrets",
 		"artifacts": "Artifacts",
-		"auto-update": "Auto-Update"
+		"auto-update": "Auto-Update",
+		"ai-assistant": "AI Assistant"
 	},
 	"common": {
 		"search": "Search...",

--- a/frontend/src/routes/(authenticated)/ai-assistant/+page.svelte
+++ b/frontend/src/routes/(authenticated)/ai-assistant/+page.svelte
@@ -1,0 +1,373 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { t } from 'svelte-i18n';
+	import { fetchWithNotify } from '$lib/fetchWithNotify';
+
+	import Send from 'lucide-svelte/icons/send-horizontal';
+	import Bot from 'lucide-svelte/icons/bot';
+	import User from 'lucide-svelte/icons/user';
+	import AlertTriangle from 'lucide-svelte/icons/alert-triangle';
+	import Sparkles from 'lucide-svelte/icons/sparkles';
+
+	interface ChatMessage {
+		role: 'user' | 'assistant';
+		content: string;
+		isPartial?: boolean;
+	}
+
+	let messages: ChatMessage[] = $state([]);
+	let userInput = $state('');
+	let isLoading = $state(false);
+	let aiStatus = $state<{ enabled: boolean; api_key_configured: boolean } | null>(null);
+	let error = $state<string | null>(null);
+	let chatEndRef: HTMLDivElement | null = $state(null);
+
+	const chatController = { abort: null as AbortController | null };
+
+	onMount(async () => {
+		try {
+			const res = await fetchWithNotify('/api/ai-assistant/status');
+			aiStatus = await res.json();
+		} catch (e) {
+			error = 'Failed to check AI assistant status';
+			console.error(e);
+		}
+	});
+
+	const scrollToBottom = () => {
+		if (chatEndRef) {
+			chatEndRef.scrollIntoView({ behavior: 'smooth' });
+		}
+	};
+
+	onMount(() => scrollToBottom());
+
+	const sendMessage = async () => {
+		const text = userInput.trim();
+		if (!text || isLoading) return;
+
+		messages = [...messages, { role: 'user', content: text }];
+		userInput = '';
+		scrollToBottom();
+
+		isLoading = true;
+		error = null;
+
+		const assistantMsg: ChatMessage = { role: 'assistant', content: '', isPartial: true };
+		messages = [...messages, assistantMsg];
+
+		try {
+			const abortController = new AbortController();
+			chatController.abort = abortController;
+
+			const response = await fetch('/api/ai-assistant/chat', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					messages: messages
+						.filter((m) => !m.isPartial)
+						.map((m) => ({
+							role: m.role,
+							content: m.content
+						})),
+					stream: true
+				}),
+				signal: abortController.signal
+			});
+
+			if (!response.ok) {
+				const errText = await response.text();
+				throw new Error(`API error ${response.status}: ${errText}`);
+			}
+
+			const reader = response.body?.getReader();
+			if (!reader) throw new Error('No response body');
+
+			const decoder = new TextDecoder();
+			let buffer = '';
+
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+
+				buffer += decoder.decode(value, { stream: true });
+				const lines = buffer.split('\n');
+				buffer = lines.pop() || '';
+
+				for (const line of lines) {
+					if (!line.startsWith('data: ')) continue;
+					const data = line.slice(6);
+
+					if (data === '[DONE]') {
+						assistantMsg.isPartial = false;
+						continue;
+					}
+
+					try {
+						const parsed = JSON.parse(data);
+						if (parsed.content) {
+							assistantMsg.content += parsed.content;
+							scrollToBottom();
+						}
+					} catch {
+						// Skip non-JSON SSE lines
+					}
+				}
+			}
+		} catch (e) {
+			if (e instanceof DOMException && e.name === 'AbortError') return;
+			error = e instanceof Error ? e.message : 'Unknown error';
+			assistantMsg.isPartial = false;
+		} finally {
+			isLoading = false;
+			chatController.abort = null;
+			scrollToBottom();
+		}
+	};
+
+	const stopGeneration = () => {
+		chatController.abort?.abort();
+		chatController.abort = null;
+		isLoading = false;
+		// Mark the partial message as complete
+		const lastMsg = messages[messages.length - 1];
+		if (lastMsg?.isPartial) {
+			lastMsg.isPartial = false;
+		}
+	};
+
+	const handleKeydown = (e: KeyboardEvent) => {
+		if (e.key === 'Enter' && !e.shiftKey) {
+			e.preventDefault();
+			sendMessage();
+		}
+	};
+
+	const clearChat = () => {
+		messages = [];
+		error = null;
+	};
+
+	onDestroy(() => {
+		chatController.abort?.abort();
+	});
+</script>
+
+<div class="flex flex-col h-full max-w-4xl mx-auto">
+	<!-- Header -->
+	<div class="flex items-center gap-3 p-4 border-b border-gray-200 dark:border-gray-700">
+		<div class="p-2 rounded-lg bg-blue-100 dark:bg-blue-900/30">
+			<Sparkles class="w-5 h-5 text-blue-600 dark:text-blue-400" />
+		</div>
+		<div class="flex-1">
+			<h1 class="text-lg font-semibold text-gray-900 dark:text-white">{$t('nav.ai-assistant')}</h1>
+			<p class="text-xs text-gray-500 dark:text-gray-400">
+				{aiStatus?.enabled
+					? aiStatus.api_key_configured
+						? 'Connected — Ready to help'
+						: 'Connected — No API key configured'
+					: 'AI Assistant disabled'}
+			</p>
+		</div>
+		{#if messages.length > 0}
+			<button
+				onclick={clearChat}
+				class="px-3 py-1.5 text-sm rounded-lg border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+			>
+				Clear
+			</button>
+		{/if}
+	</div>
+
+	<!-- Status warnings -->
+	{#if !aiStatus?.enabled}
+		<div
+			class="mx-4 mt-4 p-3 rounded-lg bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 flex items-start gap-2"
+		>
+			<AlertTriangle class="w-4 h-4 text-yellow-600 dark:text-yellow-400 mt-0.5 shrink-0" />
+			<div>
+				<p class="text-sm font-medium text-yellow-800 dark:text-yellow-300">
+					AI Assistant Disabled
+				</p>
+				<p class="text-xs text-yellow-700 dark:text-yellow-400 mt-1">
+					Set <code class="font-mono text-xs bg-yellow-100 dark:bg-yellow-900/40 px-1 rounded"
+						>THYMIS_AI_ASSISTANT_ENABLED=true</code
+					> in your environment to enable.
+				</p>
+			</div>
+		</div>
+	{:else if aiStatus?.enabled && !aiStatus.api_key_configured}
+		<div
+			class="mx-4 mt-4 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 flex items-start gap-2"
+		>
+			<AlertTriangle class="w-4 h-4 text-amber-600 dark:text-amber-400 mt-0.5 shrink-0" />
+			<div>
+				<p class="text-sm font-medium text-amber-800 dark:text-amber-300">API Key Not Configured</p>
+				<p class="text-xs text-amber-700 dark:text-amber-400 mt-1">
+					Set <code class="font-mono text-xs bg-amber-100 dark:bg-amber-900/40 px-1 rounded"
+						>THYMIS_AI_ASSISTANT_API_KEY</code
+					> to use the assistant.
+				</p>
+			</div>
+		</div>
+	{/if}
+
+	<!-- Error -->
+	{#if error}
+		<div
+			class="mx-4 mt-4 p-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 flex items-start gap-2"
+		>
+			<AlertTriangle class="w-4 h-4 text-red-600 dark:text-red-400 mt-0.5 shrink-0" />
+			<p class="text-sm text-red-800 dark:text-red-300">{error}</p>
+		</div>
+	{/if}
+
+	<!-- Chat messages -->
+	<div class="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+		{#if messages.length === 0}
+			<div class="flex flex-col items-center justify-center h-full text-center py-12">
+				<Bot class="w-12 h-12 text-gray-300 dark:text-gray-600 mb-4" />
+				<p class="text-gray-500 dark:text-gray-400 text-sm">
+					Ask me anything about your Thymis configuration, modules, or deployments.
+				</p>
+				<div class="mt-4 space-y-2">
+					<button
+						onclick={() => {
+							userInput = 'How do I configure a Raspberry Pi 4 as a Kiosk?';
+						}}
+						class="block text-left text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors p-2 rounded hover:bg-gray-50 dark:hover:bg-gray-800"
+					>
+						"How do I configure a Raspberry Pi 4 as a Kiosk?"
+					</button>
+					<button
+						onclick={() => {
+							userInput = 'What modules are available for device configuration?';
+						}}
+						class="block text-left text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors p-2 rounded hover:bg-gray-50 dark:hover:bg-gray-800"
+					>
+						"What modules are available for device configuration?"
+					</button>
+					<button
+						onclick={() => {
+							userInput = 'How do I add a custom NixOS module?';
+						}}
+						class="block text-left text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors p-2 rounded hover:bg-gray-50 dark:hover:bg-gray-800"
+					>
+						"How do I add a custom NixOS module?"
+					</button>
+				</div>
+			</div>
+		{/if}
+
+		{#each messages as message (message.role + message.content)}
+			<div class="flex gap-3 {message.role === 'user' ? 'flex-row-reverse' : ''}">
+				<!-- Avatar -->
+				<div class="shrink-0 mt-1">
+					{#if message.role === 'user'}
+						<div
+							class="w-8 h-8 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center"
+						>
+							<User class="w-4 h-4 text-blue-600 dark:text-blue-400" />
+						</div>
+					{:else}
+						<div
+							class="w-8 h-8 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center"
+						>
+							<Bot class="w-4 h-4 text-green-600 dark:text-green-400" />
+						</div>
+					{/if}
+				</div>
+
+				<!-- Message bubble -->
+				<div
+					class="max-w-[80%] rounded-xl px-4 py-3 text-sm leading-relaxed whitespace-pre-wrap break-words {message.role ===
+					'user'
+						? 'bg-blue-600 text-white'
+						: 'bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100'}"
+				>
+					{message.content || (message.isPartial ? '...' : '')}
+					{#if message.isPartial}
+						<span class="inline-block w-1.5 h-4 ml-1 bg-gray-400 dark:bg-gray-500 animate-pulse"
+						></span>
+					{/if}
+				</div>
+			</div>
+		{/each}
+
+		<!-- Loading indicator -->
+		{#if isLoading && messages.length === 0}
+			<div class="flex gap-3">
+				<div
+					class="w-8 h-8 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center shrink-0"
+				>
+					<Bot class="w-4 h-4 text-green-600 dark:text-green-400" />
+				</div>
+				<div
+					class="max-w-[80%] rounded-xl px-4 py-3 bg-gray-100 dark:bg-gray-800 flex gap-1.5 items-center"
+				>
+					<span class="w-2 h-2 rounded-full bg-gray-400 animate-bounce" style="animation-delay: 0ms"
+					></span>
+					<span
+						class="w-2 h-2 rounded-full bg-gray-400 animate-bounce"
+						style="animation-delay: 150ms"
+					></span>
+					<span
+						class="w-2 h-2 rounded-full bg-gray-400 animate-bounce"
+						style="animation-delay: 300ms"
+					></span>
+				</div>
+			</div>
+		{/if}
+
+		<div bind:this={chatEndRef}></div>
+	</div>
+
+	<!-- Input area -->
+	<div class="p-4 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
+		<div class="flex gap-2 max-w-4xl mx-auto">
+			<textarea
+				bind:value={userInput}
+				onkeydown={handleKeydown}
+				disabled={isLoading || !aiStatus?.enabled}
+				placeholder="Ask about your Thymis project..."
+				rows={1}
+				class="flex-1 resize-none rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-4 py-3 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 transition-colors"
+				oninput={(e: Event) => {
+					const target = e.target as HTMLTextAreaElement;
+					target.style.height = 'auto';
+					target.style.height = Math.min(target.scrollHeight, 160) + 'px';
+				}}
+			></textarea>
+			{#if isLoading}
+				<button
+					onclick={stopGeneration}
+					class="shrink-0 px-4 py-3 rounded-xl bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50 transition-colors"
+					title="Stop generation"
+				>
+					<svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+						<rect x="6" y="6" width="12" height="12" rx="2" />
+					</svg>
+				</button>
+			{:else}
+				<button
+					onclick={sendMessage}
+					disabled={!userInput.trim() || !aiStatus?.enabled}
+					class="shrink-0 px-4 py-3 rounded-xl bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-300 dark:disabled:bg-gray-700 disabled:text-gray-500 dark:disabled:text-gray-400 transition-colors disabled:cursor-not-allowed"
+				>
+					<Send class="w-5 h-5" />
+				</button>
+			{/if}
+		</div>
+		<p class="text-xs text-gray-400 dark:text-gray-500 text-center mt-2">
+			AI can make mistakes. Verify important configurations before deploying.
+		</p>
+	</div>
+</div>
+
+<style lang="postcss">
+	:global(.dark) {
+		textarea {
+			caret-color: white;
+		}
+	}
+</style>

--- a/frontend/src/routes/(authenticated)/configuration/(subpages)/logs/+page.svelte
+++ b/frontend/src/routes/(authenticated)/configuration/(subpages)/logs/+page.svelte
@@ -24,7 +24,7 @@
 	let { data }: Props = $props();
 
 	let downloadOpen = $state(false);
-	let refreshInterval = $state(1000);
+	let refreshInterval = $state(5000);
 
 	const refreshIntervals = [
 		{ label: $t('logs.refresh_off'), value: 0 },


### PR DESCRIPTION
## Problem

The logging page fires a request every second, but the request took longer than 1s — requests queued up and the page became unusable.

## Fixes

### 1. Remove `func.count().over()` window function (`crud/logs.py`)

The window function forced SQLite to scan **all** matching rows to compute `total_count`, even though only 40 rows were returned. Replaced with a separate `COUNT` query that leverages indexes, then fetches only the requested page.

### 2. Add composite indexes (`db_models/logs.py` + Alembic migration)

Queries filter on `deployment_info_id`/ `ssh_public_key` + sort by `timestamp DESC`, but the only index was on `timestamp` alone. Added two composite indexes:

- `ix_log_entries_deployment_info_id_timestamp`
- `ix_log_entries_ssh_public_key_timestamp`

### 3. Change default refresh interval (`+page.svelte`)

Changed the default from 1s → 5s to prevent request queuing even on large datasets.