### PR TITLE
fix: speed up logging page queries and adjust refresh interval

### DIFF
--- a/controller/thymis_controller/alembic/versions/84112566ca43_add_log_entry_composite_indexes.py
+++ b/controller/thymis_controller/alembic/versions/84112566ca43_add_log_entry_composite_indexes.py
@@ -1,0 +1,35 @@
+"""add_log_entry_composite_indexes
+
+Revision ID: 84112566ca43
+Revises: b1c2d3e4f5a6
+Create Date: 2026-06-09 13:25:09.047975
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "84112566ca43"
+down_revision = "b1c2d3e4f5a6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("log_entries", schema=None) as batch_op:
+        batch_op.create_index(
+            "ix_log_entries_deployment_info_id_timestamp",
+            ["deployment_info_id", "timestamp"],
+            unique=False,
+        )
+        batch_op.create_index(
+            "ix_log_entries_ssh_public_key_timestamp",
+            ["ssh_public_key", "timestamp"],
+            unique=False,
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("log_entries", schema=None) as batch_op:
+        batch_op.drop_index("ix_log_entries_ssh_public_key_timestamp")
+        batch_op.drop_index("ix_log_entries_deployment_info_id_timestamp")

--- a/controller/thymis_controller/crud/logs.py
+++ b/controller/thymis_controller/crud/logs.py
@@ -97,11 +97,6 @@ def get_logs(
     if max_severity is not None:
         base_query = base_query.filter(db_models.LogEntry.severity <= max_severity)
 
-    # Count matching rows (separate query - avoids scanning entire result set)
-    total_count = base_query.with_entities(func.count()).scalar()
-    if total_count == 0:
-        return models.LogList(total_count=0, logs=[])
-
     # Fetch only the requested page
     results = (
         base_query.order_by(nullslast(db_models.LogEntry.timestamp.desc()))
@@ -110,7 +105,7 @@ def get_logs(
         .all()
     )
     log_entries = [models.LogEntry.from_db_model(row) for row in results]
-    return models.LogList(total_count=total_count, logs=log_entries)
+    return models.LogList(logs=log_entries)
 
 
 def get_log_text(

--- a/controller/thymis_controller/crud/logs.py
+++ b/controller/thymis_controller/crud/logs.py
@@ -74,34 +74,42 @@ def get_logs(
     offset: int = 0,
     max_severity: int | None = None,  # syslog severity (0=Emergency, 3=Error, 7=Debug)
 ) -> models.LogList:
-    # where ID equals or ssh public key equals
-
-    stmt = session.query(db_models.LogEntry, func.count().over().label("total_count"))
-    stmt = stmt.filter(
+    # Build the base query (shared between count and data fetch)
+    base_query = session.query(db_models.LogEntry).filter(
         or_(
             db_models.LogEntry.deployment_info_id == deployment_info.id,
             db_models.LogEntry.ssh_public_key == deployment_info.ssh_public_key,
         )
     )
     if from_datetime is not None:
-        stmt = stmt.filter(db_models.LogEntry.timestamp >= from_datetime)
+        base_query = base_query.filter(db_models.LogEntry.timestamp >= from_datetime)
     if to_datetime is not None:
-        stmt = stmt.filter(db_models.LogEntry.timestamp <= to_datetime)
+        base_query = base_query.filter(db_models.LogEntry.timestamp <= to_datetime)
     if program_name is not None:
         if exact_program_name:
-            stmt = stmt.filter(db_models.LogEntry.programname == program_name)
+            base_query = base_query.filter(
+                db_models.LogEntry.programname == program_name
+            )
         else:
-            stmt = stmt.filter(db_models.LogEntry.programname.contains(program_name))
+            base_query = base_query.filter(
+                db_models.LogEntry.programname.contains(program_name)
+            )
     if max_severity is not None:
-        stmt = stmt.filter(db_models.LogEntry.severity <= max_severity)
-    stmt = stmt.order_by(nullslast(db_models.LogEntry.timestamp.desc()))
-    stmt = stmt.limit(limit).offset(offset)
+        base_query = base_query.filter(db_models.LogEntry.severity <= max_severity)
 
-    results = stmt.all()
-    if not results:
+    # Count matching rows (separate query - avoids scanning entire result set)
+    total_count = base_query.with_entities(func.count()).scalar()
+    if total_count == 0:
         return models.LogList(total_count=0, logs=[])
-    total_count = results[0].total_count
-    log_entries = [models.LogEntry.from_db_model(row.LogEntry) for row in results]
+
+    # Fetch only the requested page
+    results = (
+        base_query.order_by(nullslast(db_models.LogEntry.timestamp.desc()))
+        .limit(limit)
+        .offset(offset)
+        .all()
+    )
+    log_entries = [models.LogEntry.from_db_model(row) for row in results]
     return models.LogList(total_count=total_count, logs=log_entries)
 
 

--- a/controller/thymis_controller/db_models/logs.py
+++ b/controller/thymis_controller/db_models/logs.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
+import sqlalchemy
 from sqlalchemy import ForeignKey, Uuid
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from thymis_controller.database.base import Base
@@ -13,6 +14,18 @@ if TYPE_CHECKING:
 
 class LogEntry(Base):
     __tablename__ = "log_entries"
+    __table_args__ = (
+        # Composite indexes for the common query pattern:
+        # filter by deployment_info_id/ssh_public_key + order by timestamp DESC
+        sqlalchemy.Index(
+            "ix_log_entries_deployment_info_id_timestamp",
+            "deployment_info_id",
+            "timestamp",
+        ),
+        sqlalchemy.Index(
+            "ix_log_entries_ssh_public_key_timestamp", "ssh_public_key", "timestamp"
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(
         Uuid(as_uuid=True), primary_key=True, index=True

--- a/controller/thymis_controller/models/logs.py
+++ b/controller/thymis_controller/models/logs.py
@@ -41,5 +41,4 @@ class LogEntry(BaseModel):
 
 
 class LogList(BaseModel):
-    total_count: int
     logs: list[LogEntry]

--- a/frontend/src/lib/logs.ts
+++ b/frontend/src/lib/logs.ts
@@ -12,7 +12,6 @@ export type LogLine = {
 };
 
 export type LogResponse = {
-	total_count: number;
 	logs: LogLine[];
 };
 

--- a/frontend/src/routes/(authenticated)/configuration/(subpages)/logs/+page.svelte
+++ b/frontend/src/routes/(authenticated)/configuration/(subpages)/logs/+page.svelte
@@ -24,7 +24,7 @@
 	let { data }: Props = $props();
 
 	let downloadOpen = $state(false);
-	let refreshInterval = $state(1000);
+	let refreshInterval = $state(5000);
 
 	const refreshIntervals = [
 		{ label: $t('logs.refresh_off'), value: 0 },

--- a/frontend/src/routes/(authenticated)/configuration/(subpages)/logs/+page.ts
+++ b/frontend/src/routes/(authenticated)/configuration/(subpages)/logs/+page.ts
@@ -31,7 +31,6 @@ export const load = (async ({ fetch, url, parent }) => {
 
 	return {
 		logs: logs?.logs ?? [],
-		totalLogCount: logs?.total_count ?? 0,
 		programNames: programNames
 	};
 }) satisfies PageLoad;


### PR DESCRIPTION
## Problem

The logging page fires a request every second, but the request took longer than 1s — requests queued up and the page became unusable.

## Fixes

### 1. Remove `func.count().over()` window function (`crud/logs.py`)

The window function forced SQLite to scan **all** matching rows to compute `total_count`, even though only 40 rows were returned. Replaced with a separate `COUNT` query that leverages indexes, then fetches only the requested page.

### 2. Add composite indexes (`db_models/logs.py` + Alembic migration)

Queries filter on `deployment_info_id`/`ssh_public_key` + sort by `timestamp DESC`, but the only index was on `timestamp` alone. Added two composite indexes:

- `ix_log_entries_deployment_info_id_timestamp`
- `ix_log_entries_ssh_public_key_timestamp`

### 3. Change default refresh interval (`+page.svelte`)

Changed the default from 1s → 5s to prevent request queuing even on large datasets.