### PR TITLE
feat: pass user identity through to git commit authors

### DIFF
--- a/controller/thymis_controller/dependencies.py
+++ b/controller/thymis_controller/dependencies.py
@@ -17,7 +17,7 @@ from fastapi import (
 )
 from fastapi.requests import HTTPConnection
 from fastapi.security import HTTPBearer
-from pydantic import Json
+from pydantic import BaseModel, Json
 from sqlalchemy import Engine
 from sqlalchemy.orm import Session
 from thymis_controller.config import global_settings
@@ -72,6 +72,53 @@ DBSessionAD = Annotated[Session, Depends(get_db_session)]
 UserSessionIDAD = Annotated[Optional[uuid.UUID], Cookie(alias="session-id")]
 
 UserSessionTokenAD = Annotated[Optional[str], Cookie(alias="session-token")]
+
+
+class UserInfo(BaseModel):
+    username: Optional[str] = None
+    given_name: Optional[str] = None
+    family_name: Optional[str] = None
+    email: Optional[str] = None
+
+
+def get_user_info(
+    db_session: DBSessionAD,
+    user_session_id: UserSessionIDAD = None,
+) -> Optional[UserInfo]:
+    if user_session_id is None:
+        return None
+    session = web_session.get(db_session, user_session_id)
+    if session is None:
+        return None
+    return UserInfo(
+        username=session.username,
+        given_name=session.given_name,
+        family_name=session.family_name,
+        email=session.email,
+    )
+
+
+UserInfoAD = Annotated[Optional[UserInfo], Depends(get_user_info)]
+
+
+def git_author_from_user_info(
+    user_info: Optional[UserInfo],
+) -> Optional[tuple[str, str]]:
+    """Build a (name, email) git author tuple from a UserInfo, or None."""
+    if not user_info:
+        return None
+    name = (
+        f"{user_info.given_name} {user_info.family_name}"
+        if user_info.given_name and user_info.family_name
+        else user_info.username
+    )
+    email = user_info.email or (
+        f"{user_info.username}@thymis.local" if user_info.username else None
+    )
+    if name and email:
+        return (name, email)
+    return None
+
 
 LoginRedirectCookieAD = Annotated[Optional[str], Cookie(alias="login-redirect")]
 

--- a/controller/thymis_controller/dependencies.py
+++ b/controller/thymis_controller/dependencies.py
@@ -5,23 +5,14 @@ import uuid
 from typing import Annotated, Generator, Optional, Union
 
 import httpx
-from fastapi import (
-    Cookie,
-    Depends,
-    Header,
-    HTTPException,
-    Request,
-    Response,
-    WebSocket,
-    status,
-)
+from fastapi import Cookie, Depends, HTTPException, Response, status
 from fastapi.requests import HTTPConnection
 from fastapi.security import HTTPBearer
-from pydantic import BaseModel, Json
 from sqlalchemy import Engine
 from sqlalchemy.orm import Session
 from thymis_controller.config import global_settings
 from thymis_controller.crud import web_session
+from thymis_controller.models.auth import UserInfo
 from thymis_controller.network_relay import NetworkRelay
 from thymis_controller.notifications import NotificationManager
 from thymis_controller.project import Project
@@ -72,13 +63,6 @@ DBSessionAD = Annotated[Session, Depends(get_db_session)]
 UserSessionIDAD = Annotated[Optional[uuid.UUID], Cookie(alias="session-id")]
 
 UserSessionTokenAD = Annotated[Optional[str], Cookie(alias="session-token")]
-
-
-class UserInfo(BaseModel):
-    username: Optional[str] = None
-    given_name: Optional[str] = None
-    family_name: Optional[str] = None
-    email: Optional[str] = None
 
 
 def get_user_info(

--- a/controller/thymis_controller/models/__init__.py
+++ b/controller/thymis_controller/models/__init__.py
@@ -1,5 +1,6 @@
 from .agent_connection import *
 from .artifacts import *
+from .auth import *
 from .device import *
 from .device_metric import *
 from .fleet_alert import *

--- a/controller/thymis_controller/models/auth.py
+++ b/controller/thymis_controller/models/auth.py
@@ -1,0 +1,15 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class AuthMethods(BaseModel):
+    basic: bool
+    oauth2: bool
+
+
+class UserInfo(BaseModel):
+    username: Optional[str] = None
+    given_name: Optional[str] = None
+    family_name: Optional[str] = None
+    email: Optional[str] = None

--- a/controller/thymis_controller/models/task.py
+++ b/controller/thymis_controller/models/task.py
@@ -280,6 +280,8 @@ class AutoUpdateTaskSubmission(BaseModel):
     ssh_key_path: str
     known_hosts_path: str
     controller_ssh_pubkey: str
+    git_author_name: Optional[str] = None
+    git_author_email: Optional[str] = None
     parent_task_id: Optional[uuid.UUID] = None
 
 

--- a/controller/thymis_controller/repo.py
+++ b/controller/thymis_controller/repo.py
@@ -14,6 +14,22 @@ from watchdog.observers import Observer
 logger = logging.getLogger(__name__)
 
 
+def git_commit_cmd(
+    message: str,
+    *extra_args: str,
+    author: tuple[str, str] | None = None,
+) -> list[str]:
+    """Build a ``git commit`` command list.
+
+    Both :meth:`Repo.commit` and the task worker construct commit commands
+    through this helper so the flags stay in sync.
+    """
+    cmd = ["git", "commit", "-m", message, *extra_args]
+    if author:
+        cmd.extend(["--author", f"{author[0]} <{author[1]}>"])
+    return cmd
+
+
 class Commit(BaseModel):
     SHA: str
     SHA1: str
@@ -145,9 +161,9 @@ class Repo:
         logger.info(f"Adding changed files to git index: {', '.join(unstaged_files)}")
         self.run_command("git", "add", *files)
 
-    def commit(self, message: str):
+    def commit(self, message: str, author: tuple[str, str] | None = None):
         logger.info(f"Committing changes to git: {message}")
-        self.run_command("git", "commit", "-m", message)
+        self.run_command(*git_commit_cmd(message, author=author))
 
     def head_commit(self) -> str:
         return self.run_command("git", "rev-parse", "HEAD")

--- a/controller/thymis_controller/routers/api_action.py
+++ b/controller/thymis_controller/routers/api_action.py
@@ -14,7 +14,9 @@ from thymis_controller.dependencies import (
     NetworkRelayAD,
     ProjectAD,
     TaskControllerAD,
+    UserInfoAD,
     UserSessionIDAD,
+    git_author_from_user_info,
 )
 from thymis_controller.models.state import State
 
@@ -368,9 +370,9 @@ async def switch_config(
 
 
 @router.post("/action/commit")
-def commit(project: ProjectAD, message: str):
+def commit(project: ProjectAD, message: str, user_info: UserInfoAD = None):
     project.repo.add(".")
-    project.repo.commit(message)
+    project.repo.commit(message, author=git_author_from_user_info(user_info))
     return {"message": "commit successful"}
 
 
@@ -395,6 +397,7 @@ async def auto_update(
     network_relay: NetworkRelayAD,
     user_session_id: UserSessionIDAD,
     db_session: DBSessionAD,
+    user_info: UserInfoAD = None,
 ):
     devices: list[models.DeployDeviceInformation] = []
 
@@ -441,6 +444,8 @@ async def auto_update(
     project.update_known_hosts(session)
     access_tokens = project.nix_access_tokens()
 
+    git_author = git_author_from_user_info(user_info)
+
     task_controller.submit(
         models.AutoUpdateTaskSubmission(
             project_path=str(project.path),
@@ -449,6 +454,8 @@ async def auto_update(
             ssh_key_path=str(global_settings.PROJECT_PATH / "id_thymis"),
             known_hosts_path=str(project.known_hosts_path),
             controller_ssh_pubkey=project.public_key,
+            git_author_name=git_author[0] if git_author else None,
+            git_author_email=git_author[1] if git_author else None,
         ),
         user_session_id=user_session_id,
         db_session=session,

--- a/controller/thymis_controller/routers/api_action.py
+++ b/controller/thymis_controller/routers/api_action.py
@@ -370,7 +370,7 @@ async def switch_config(
 
 
 @router.post("/action/commit")
-def commit(project: ProjectAD, message: str, user_info: UserInfoAD = None):
+def commit(project: ProjectAD, message: str, user_info: UserInfoAD):
     project.repo.add(".")
     project.repo.commit(message, author=git_author_from_user_info(user_info))
     return {"message": "commit successful"}
@@ -397,7 +397,7 @@ async def auto_update(
     network_relay: NetworkRelayAD,
     user_session_id: UserSessionIDAD,
     db_session: DBSessionAD,
-    user_info: UserInfoAD = None,
+    user_info: UserInfoAD,
 ):
     devices: list[models.DeployDeviceInformation] = []
 

--- a/controller/thymis_controller/routers/auth.py
+++ b/controller/thymis_controller/routers/auth.py
@@ -6,30 +6,18 @@ import httpx
 import jwt
 from fastapi import APIRouter, Depends, Form, HTTPException, Response, status
 from fastapi.responses import RedirectResponse
-from pydantic import BaseModel
 from thymis_controller.config import global_settings
 from thymis_controller.crud import web_session
 from thymis_controller.dependencies import (
     DBSessionAD,
     LoginRedirectCookieAD,
+    UserInfoAD,
     UserSessionIDAD,
     UserSessionTokenAD,
     invalidate_user_session,
     require_valid_user_session,
 )
-
-
-class AuthMethods(BaseModel):
-    basic: bool
-    oauth2: bool
-
-
-class UserInfo(BaseModel):
-    username: Optional[str] = None
-    given_name: Optional[str] = None
-    family_name: Optional[str] = None
-    email: Optional[str] = None
-
+from thymis_controller.models.auth import AuthMethods, UserInfo
 
 REDIRECT_URI = global_settings.BASE_URL + "/auth/callback"
 
@@ -287,22 +275,9 @@ async def callback(
     response_model=UserInfo,
     dependencies=[Depends(require_valid_user_session)],
 )
-def is_logged_in(
-    db_session: DBSessionAD,
-    user_session_id: UserSessionIDAD = None,
-):
-    if not user_session_id:
+def is_logged_in(user_info: UserInfoAD):
+    if user_info is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="No valid session"
         )
-    session = web_session.get(db_session, user_session_id)
-    if session is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="No valid session"
-        )
-    return UserInfo(
-        username=session.username,
-        given_name=session.given_name,
-        family_name=session.family_name,
-        email=session.email,
-    )
+    return user_info

--- a/controller/thymis_controller/task/worker.py
+++ b/controller/thymis_controller/task/worker.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel
 from thymis_agent import agent
 from thymis_controller.nix import NIX_CMD, NIX_SSHOPTS
 from thymis_controller.nix.log_parse import NixParser
+from thymis_controller.repo import git_commit_cmd
 
 
 def access_client_proxy_command(
@@ -750,11 +751,16 @@ def auto_update_task(
             report_task_finished(task, conn, False, "git add flake.lock failed")
             return
 
+        author = (
+            (task_data.git_author_name, task_data.git_author_email)
+            if task_data.git_author_name and task_data.git_author_email
+            else None
+        )
         commit_returncode = run_command(
             task,
             conn,
             process_list,
-            ["git", "commit", "--allow-empty", "-m", "flake.lock: Auto-update"],
+            git_commit_cmd("flake.lock: Auto-update", "--allow-empty", author=author),
             env=git_env,
             cwd=str(repo_path),
             process_index=3,


### PR DESCRIPTION
## What

When a user commits via the UI or triggers an auto-update, their account name and email are now forwarded as the git author instead of the generic `Thymis Controller` identity.

## Changes

- **`repo.py`**: Add `git_commit_cmd()` helper — single source of truth for constructing `git commit` commands. `Repo.commit()` delegates to it.
- **`dependencies.py`**: New `UserInfo` model, `get_user_info` dependency (fetches from WebSession), and `git_author_from_user_info()` helper that derives a `(name, email)` tuple.
- **`api_action.py`**: `/action/commit` and `/action/auto-update` inject `UserInfoAD` and pass the derived author to git.
- **`models/task.py`**: `AutoUpdateTaskSubmission` gains optional `git_author_name` / `git_author_email` fields.
- **`task/worker.py`**: `auto_update_task` uses `git_commit_cmd()` — same code path as `Repo.commit()`.

## Author resolution

| Trigger | Author |
|---|---|
| UI commit (logged in) | User full name + email |
| Auto-update (user-initiated) | User full name + email |
| Auto-update (scheduler) | Repo default (`Thymis Controller`) |
| Initial commit | Repo default (no user context) |

For basic auth users without an email, `{username}@thymis.local` is used.