### PR TITLE
feat: update NixOS support to 26.05

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: pin nixpkgs
-        run: nix registry add nixpkgs github:NixOS/nixpkgs/nixos-25.11
+        run: nix registry add nixpkgs github:NixOS/nixpkgs/nixos-26.05
       - uses: ./.github/actions/snapshot-nix-store
       - name: Build thymis-controller-generic-x86_64-image
         timeout-minutes: 360

--- a/controller/tests/integration/test_x86_vm_api.py
+++ b/controller/tests/integration/test_x86_vm_api.py
@@ -46,7 +46,7 @@ import requests
 # constants
 # ─────────────────────────────────────────────────────────────────────────────
 
-REPO_ROOT = pathlib.Path(__file__).parents[3]  # …/thymis-25.11
+REPO_ROOT = pathlib.Path(__file__).parents[3]  # …/thymis-26.05
 
 # Module type strings used in state JSON payloads
 MOD_THYMIS_DEVICE = "thymis_controller.modules.thymis.ThymisDevice"
@@ -382,7 +382,7 @@ def test_x86_vm_build_start_deploy(controller: ControllerInfo) -> None:
                     "settings": {
                         "device_type": "generic-x86_64",
                         "image_format": "nixos-vm",
-                        "nix_state_version": "25.11",
+                        "nix_state_version": "26.05",
                     },
                 }
             ],

--- a/controller/tests/utils/test_module_split.py
+++ b/controller/tests/utils/test_module_split.py
@@ -213,6 +213,9 @@ def test_device_module_keeps_core_settings_and_writes_imports():
         "nix_state_version",
         "agent_controller_url",
     }
+    nix_state_version = model.settings["nix_state_version"]
+    assert nix_state_version.default == "26.05"
+    assert ("26.05", "26.05") in nix_state_version.type.select_one
     out = _write(device, {"device_type": "generic-x86_64", "image_format": "nixos-vm"})
     assert "imports = [" in out
     assert "thymis-device-generic-x86_64" in out

--- a/controller/thymis_controller/modules/thymis.py
+++ b/controller/thymis_controller/modules/thymis.py
@@ -110,8 +110,10 @@ class ThymisDevice(modules.Module):
             de="NixOS State Version",
         ),
         nix_attr_name="system.stateVersion",
-        type=modules.SelectOneType(select_one=["24.05", "24.11", "25.05", "25.11"]),
-        default="25.11",
+        type=modules.SelectOneType(
+            select_one=["24.05", "24.11", "25.05", "25.11", "26.05"]
+        ),
+        default="26.05",
         description=modules.LocalizedString(
             en="The NixOS state version.",
             de="Die NixOS Zustandsversion.",

--- a/flake.lock
+++ b/flake.lock
@@ -46,16 +46,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1779506708,
-        "narHash": "sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0=",
+        "lastModified": 1784350909,
+        "narHash": "sha256-ZWyzLbS1yKUTeFJLmdVuWNnHttL333/ldJbEE+KzCrM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f",
+        "rev": "4ce190229c73d44536caa7072f6308fb2d8feeb3",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -163,16 +163,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1782847189,
-        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
+        "lastModified": 1784432872,
+        "narHash": "sha256-n3gKTBIV4ZA5VQpUakffBe3KGu4+mhPoA34rrqS0GkA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
+        "rev": "fd1462031fdee08f65fd0b4c6b64e22239a77870",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,8 @@
   description = "Thymis";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
-    home-manager.url = "github:nix-community/home-manager/release-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
+    home-manager.url = "github:nix-community/home-manager/release-26.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
     nixos-generators.url = "github:nix-community/nixos-generators";
     nixos-generators.inputs.nixpkgs.follows = "nixpkgs";
@@ -74,7 +74,7 @@
         services.thymis-controller.enable = true;
         services.thymis-controller.base-url = "https://thymis.example.com";
         services.thymis-controller.agent-access-url = "https://thymis.example.com";
-        system.stateVersion = "25.11";
+        system.stateVersion = "26.05";
       };
 
       thymis-controller-pi-3-sd-image = (nixpkgs.lib.nixosSystem {

--- a/frontend/default.nix
+++ b/frontend/default.nix
@@ -10,6 +10,7 @@ buildNpmPackage {
   version = (builtins.fromJSON (builtins.readFile ./package.json)).version;
   src = ./.;
   npmDepsHash = "sha256-rDACghOfAZl6YfnfTUqp1wIUqPm+PsArBEg/onG3fOE=";
+  # Keep in sync with frontend/package-lock.json.
   dontNpmInstall = true;
   NODE_OPTIONS = "--max-old-space-size=8192";
   installPhase = ''

--- a/frontend/default.nix
+++ b/frontend/default.nix
@@ -9,7 +9,7 @@ buildNpmPackage {
   pname = "thymis-frontend";
   version = (builtins.fromJSON (builtins.readFile ./package.json)).version;
   src = ./.;
-  npmDepsHash = "sha256-rDACghOfAZl6YfnfTUqp1wIUqPm+PsArBEg/onG3fOE=";
+  npmDepsHash = "sha256-sEsMJQmoGdo1FTa0tcIa99McbHkFjrwp62D382jdivc=";
   # Keep in sync with frontend/package-lock.json.
   dontNpmInstall = true;
   NODE_OPTIONS = "--max-old-space-size=8192";

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.9.3-dev",
 			"devDependencies": {
 				"@novnc/novnc": "npm:@elikoga/novnc@^1.6.0",
-				"@playwright/test": "1.56.1",
+				"@playwright/test": "1.59.1",
 				"@prgm/sveltekit-progress-bar": "^3.0.2",
 				"@sveltejs/adapter-node": "^5.5.4",
 				"@sveltejs/kit": "^2.65.2",
@@ -445,13 +445,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.56.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
-			"integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.56.1"
+				"playwright": "1.59.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -4254,13 +4254,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.56.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
-			"integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.56.1"
+				"playwright-core": "1.59.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -4273,9 +4273,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.56.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
-			"integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
 	},
 	"devDependencies": {
 		"@novnc/novnc": "npm:@elikoga/novnc@^1.6.0",
-		"@playwright/test": "1.56.1",
+		"@playwright/test": "1.59.1",
 		"@prgm/sveltekit-progress-bar": "^3.0.2",
 		"@sveltejs/adapter-node": "^5.5.4",
 		"@sveltejs/kit": "^2.65.2",

--- a/frontend/src/routes/(authenticated)/configuration/list/CreateConfigModal.svelte
+++ b/frontend/src/routes/(authenticated)/configuration/list/CreateConfigModal.svelte
@@ -52,7 +52,7 @@
 				getAllowedImageFormatsForDeviceType(selectedDeviceType, availableModules)?.[0] ||
 				'sd-card-image',
 			device_name: identifier,
-			nix_state_version: '25.11'
+			nix_state_version: '26.05'
 		};
 		const config: Config = {
 			displayName,


### PR DESCRIPTION
## Summary
- update nixpkgs and Home Manager to the 26.05 release
- make 26.05 the default Thymis device state version while retaining older selectable versions
- update CI and integration fixtures

## Verification
- `nix flake check --all-systems --no-build --show-trace`
- `nix build .#thymis-controller-generic-x86_64-image --no-link --print-build-logs --fallback`
- `nix build .#thymis-controller-pi-3-sd-image --no-link --print-build-logs --fallback`
- `nix build .#thymis-controller-pi-4-sd-image --no-link --print-build-logs --fallback`
- `nix build .#thymis-controller-pi-5-sd-image --no-link --print-build-logs --fallback`
- `uv run pytest tests/utils/test_module_split.py -q` (8 passed)

The image builds emit existing deprecation/rename warnings from nixos-generators and Raspberry Pi modules; all builds complete successfully.