### PR TITLE
fix: force-enable HDMI on Raspberry Pis

### DIFF
--- a/nix/devices.nix
+++ b/nix/devices.nix
@@ -9,6 +9,9 @@ let
       generic-aarch64 = { ... }: {
         nixpkgs.hostPlatform = "aarch64-linux";
       };
+      # The HDMI force-enable parameters below follow the recommendation of 6by9,
+      # Raspberry Pi engineer and forum moderator:
+      # https://forums.raspberrypi.com/viewtopic.php?t=383225
       raspberry-pi-3 = { modulesPath, ... }: {
         disabledModules = [
           "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
@@ -29,6 +32,7 @@ let
           };
         };
         boot.kernelModules = [ "vc4" "bcm2835_dma" "i2c_bcm2835" ];
+        boot.kernelParams = [ "video=HDMI-A-1:D" ];
         boot.kernel.sysctl."vm.mmap_rnd_bits" = 24;
         nixpkgs.overlays = [
           (final: prev: {
@@ -53,7 +57,7 @@ let
         systemd.watchdog.runtimeTime = "15s";
         raspberry-pi-nix.libcamera-overlay.enable = false;
         raspberry-pi-nix.board = "bcm2711";
-        boot.kernelParams = [ "snd_bcm2835.enable_headphones=1" "snd_bcm2835.enable_hdmi=1" "brcmfmac.roamoff=1" "brcmfmac.feature_disable=0x282000" ];
+        boot.kernelParams = [ "video=HDMI-A-1:D" "video=HDMI-A-2:D" "snd_bcm2835.enable_headphones=1" "snd_bcm2835.enable_hdmi=1" "brcmfmac.roamoff=1" "brcmfmac.feature_disable=0x282000" ];
         boot.kernel.sysctl."vm.mmap_rnd_bits" = 24;
         hardware.raspberry-pi.config = {
           all = {
@@ -85,6 +89,7 @@ let
         systemd.watchdog.runtimeTime = "15s";
         raspberry-pi-nix.libcamera-overlay.enable = false;
         raspberry-pi-nix.board = "bcm2712";
+        boot.kernelParams = [ "video=HDMI-A-1:D" "video=HDMI-A-2:D" ];
         boot.kernel.sysctl."vm.mmap_rnd_bits" = 24;
         nixpkgs.overlays = [
           (final: prev: {


### PR DESCRIPTION
## Summary
- force HDMI-A-1 on Raspberry Pi 3 and HDMI-A-1/HDMI-A-2 on Raspberry Pi 4 and 5
- use DRM `video=<connector>:D` parameters to force each digital HDMI output enabled
- keep generic x86_64 and aarch64 device types unchanged

This follows the behavior discussed in the linked Raspberry Pi thread.

## Verification
- `nixpkgs-fmt --check nix/devices.nix`
- `nix-instantiate --parse nix/devices.nix`
- evaluated `config.boot.kernelParams` for all Pi types and generic types with `nix eval`
- `git diff --check`